### PR TITLE
HTTPS security fixes: Use TLS instead of SSL v3; actually verify server certificate.

### DIFF
--- a/libraries/Dropbox.php
+++ b/libraries/Dropbox.php
@@ -478,8 +478,10 @@ class Dropbox
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC ) ;
         curl_setopt($ch, CURLOPT_SSLVERSION, 1); // Require TLS
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($ch, CURLOPT_CAINFO, __DIR__."/certs/trusted-certs.crt");
+        curl_setopt($ch, CURLOPT_CAPATH, __DIR__."/certs/");
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request);
         curl_setopt($ch, CURLOPT_HTTPHEADER, explode(self::LINE_END, $header));

--- a/libraries/Dropbox.php
+++ b/libraries/Dropbox.php
@@ -477,7 +477,7 @@ class Dropbox
     {
         $ch = curl_init($url);
         curl_setopt($ch, CURLOPT_HTTPAUTH, CURLAUTH_BASIC ) ;
-        curl_setopt($ch, CURLOPT_SSLVERSION,3);
+        curl_setopt($ch, CURLOPT_SSLVERSION, 1); // Require TLS
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, FALSE);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/libraries/certs/trusted-certs.crt
+++ b/libraries/certs/trusted-certs.crt
@@ -1,0 +1,1396 @@
+# DigiCert Assured ID Root CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             0c:e7:e0:e5:17:d8:46:fe:8f:e5:60:fc:1b:f0:30:39
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
+#         Validity
+#             Not Before: Nov 10 00:00:00 2006 GMT
+#             Not After : Nov 10 00:00:00 2031 GMT
+#         Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Assured ID Root CA
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:ad:0e:15:ce:e4:43:80:5c:b1:87:f3:b7:60:f9:
+#                     71:12:a5:ae:dc:26:94:88:aa:f4:ce:f5:20:39:28:
+#                     58:60:0c:f8:80:da:a9:15:95:32:61:3c:b5:b1:28:
+#                     84:8a:8a:dc:9f:0a:0c:83:17:7a:8f:90:ac:8a:e7:
+#                     79:53:5c:31:84:2a:f6:0f:98:32:36:76:cc:de:dd:
+#                     3c:a8:a2:ef:6a:fb:21:f2:52:61:df:9f:20:d7:1f:
+#                     e2:b1:d9:fe:18:64:d2:12:5b:5f:f9:58:18:35:bc:
+#                     47:cd:a1:36:f9:6b:7f:d4:b0:38:3e:c1:1b:c3:8c:
+#                     33:d9:d8:2f:18:fe:28:0f:b3:a7:83:d6:c3:6e:44:
+#                     c0:61:35:96:16:fe:59:9c:8b:76:6d:d7:f1:a2:4b:
+#                     0d:2b:ff:0b:72:da:9e:60:d0:8e:90:35:c6:78:55:
+#                     87:20:a1:cf:e5:6d:0a:c8:49:7c:31:98:33:6c:22:
+#                     e9:87:d0:32:5a:a2:ba:13:82:11:ed:39:17:9d:99:
+#                     3a:72:a1:e6:fa:a4:d9:d5:17:31:75:ae:85:7d:22:
+#                     ae:3f:01:46:86:f6:28:79:c8:b1:da:e4:57:17:c4:
+#                     7e:1c:0e:b0:b4:92:a6:56:b3:bd:b2:97:ed:aa:a7:
+#                     f0:b7:c5:a8:3f:95:16:d0:ff:a1:96:eb:08:5f:18:
+#                     77:4f
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Digital Signature, Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 45:EB:A2:AF:F4:92:CB:82:31:2D:51:8B:A7:A7:21:9D:F3:6D:C8:0F
+#             X509v3 Authority Key Identifier:
+#                 keyid:45:EB:A2:AF:F4:92:CB:82:31:2D:51:8B:A7:A7:21:9D:F3:6D:C8:0F
+#
+#     Signature Algorithm: sha1WithRSAEncryption
+#          a2:0e:bc:df:e2:ed:f0:e3:72:73:7a:64:94:bf:f7:72:66:d8:
+#          32:e4:42:75:62:ae:87:eb:f2:d5:d9:de:56:b3:9f:cc:ce:14:
+#          28:b9:0d:97:60:5c:12:4c:58:e4:d3:3d:83:49:45:58:97:35:
+#          69:1a:a8:47:ea:56:c6:79:ab:12:d8:67:81:84:df:7f:09:3c:
+#          94:e6:b8:26:2c:20:bd:3d:b3:28:89:f7:5f:ff:22:e2:97:84:
+#          1f:e9:65:ef:87:e0:df:c1:67:49:b3:5d:eb:b2:09:2a:eb:26:
+#          ed:78:be:7d:3f:2b:f3:b7:26:35:6d:5f:89:01:b6:49:5b:9f:
+#          01:05:9b:ab:3d:25:c1:cc:b6:7f:c2:f1:6f:86:c6:fa:64:68:
+#          eb:81:2d:94:eb:42:b7:fa:8c:1e:dd:62:f1:be:50:67:b7:6c:
+#          bd:f3:f1:1f:6b:0c:36:07:16:7f:37:7c:a9:5b:6d:7a:f1:12:
+#          46:60:83:d7:27:04:be:4b:ce:97:be:c3:67:2a:68:11:df:80:
+#          e7:0c:33:66:bf:13:0d:14:6e:f3:7f:1f:63:10:1e:fa:8d:1b:
+#          25:6d:6c:8f:a5:b7:61:01:b1:d2:a3:26:a1:10:71:9d:ad:e2:
+#          c3:f9:c3:99:51:b7:2b:07:08:ce:2e:e6:50:b2:a7:fa:0a:45:
+#          2f:a2:f0:f2
+-----BEGIN CERTIFICATE-----
+MIIDtzCCAp+gAwIBAgIQDOfg5RfYRv6P5WD8G/AwOTANBgkqhkiG9w0BAQUFADBl
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJv
+b3QgQ0EwHhcNMDYxMTEwMDAwMDAwWhcNMzExMTEwMDAwMDAwWjBlMQswCQYDVQQG
+EwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3d3cuZGlnaWNl
+cnQuY29tMSQwIgYDVQQDExtEaWdpQ2VydCBBc3N1cmVkIElEIFJvb3QgQ0EwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCtDhXO5EOAXLGH87dg+XESpa7c
+JpSIqvTO9SA5KFhgDPiA2qkVlTJhPLWxKISKityfCgyDF3qPkKyK53lTXDGEKvYP
+mDI2dsze3Tyoou9q+yHyUmHfnyDXH+Kx2f4YZNISW1/5WBg1vEfNoTb5a3/UsDg+
+wRvDjDPZ2C8Y/igPs6eD1sNuRMBhNZYW/lmci3Zt1/GiSw0r/wty2p5g0I6QNcZ4
+VYcgoc/lbQrISXwxmDNsIumH0DJaoroTghHtORedmTpyoeb6pNnVFzF1roV9Iq4/
+AUaG9ih5yLHa5FcXxH4cDrC0kqZWs72yl+2qp/C3xag/lRbQ/6GW6whfGHdPAgMB
+AAGjYzBhMA4GA1UdDwEB/wQEAwIBhjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
+BBRF66Kv9JLLgjEtUYunpyGd823IDzAfBgNVHSMEGDAWgBRF66Kv9JLLgjEtUYun
+pyGd823IDzANBgkqhkiG9w0BAQUFAAOCAQEAog683+Lt8ONyc3pklL/3cmbYMuRC
+dWKuh+vy1dneVrOfzM4UKLkNl2BcEkxY5NM9g0lFWJc1aRqoR+pWxnmrEthngYTf
+fwk8lOa4JiwgvT2zKIn3X/8i4peEH+ll74fg38FnSbNd67IJKusm7Xi+fT8r87cm
+NW1fiQG2SVufAQWbqz0lwcy2f8Lxb4bG+mRo64EtlOtCt/qMHt1i8b5QZ7dsvfPx
+H2sMNgcWfzd8qVttevESRmCD1ycEvkvOl77DZypoEd+A5wwzZr8TDRRu838fYxAe
++o0bJW1sj6W3YQGx0qMmoRBxna3iw/nDmVG3KwcIzi7mULKn+gpFL6Lw8g==
+-----END CERTIFICATE-----
+# DigiCert Global Root CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             08:3b:e0:56:90:42:46:b1:a1:75:6a:c9:59:91:c7:4a
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root CA
+#         Validity
+#             Not Before: Nov 10 00:00:00 2006 GMT
+#             Not After : Nov 10 00:00:00 2031 GMT
+#         Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert Global Root CA
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:e2:3b:e1:11:72:de:a8:a4:d3:a3:57:aa:50:a2:
+#                     8f:0b:77:90:c9:a2:a5:ee:12:ce:96:5b:01:09:20:
+#                     cc:01:93:a7:4e:30:b7:53:f7:43:c4:69:00:57:9d:
+#                     e2:8d:22:dd:87:06:40:00:81:09:ce:ce:1b:83:bf:
+#                     df:cd:3b:71:46:e2:d6:66:c7:05:b3:76:27:16:8f:
+#                     7b:9e:1e:95:7d:ee:b7:48:a3:08:da:d6:af:7a:0c:
+#                     39:06:65:7f:4a:5d:1f:bc:17:f8:ab:be:ee:28:d7:
+#                     74:7f:7a:78:99:59:85:68:6e:5c:23:32:4b:bf:4e:
+#                     c0:e8:5a:6d:e3:70:bf:77:10:bf:fc:01:f6:85:d9:
+#                     a8:44:10:58:32:a9:75:18:d5:d1:a2:be:47:e2:27:
+#                     6a:f4:9a:33:f8:49:08:60:8b:d4:5f:b4:3a:84:bf:
+#                     a1:aa:4a:4c:7d:3e:cf:4f:5f:6c:76:5e:a0:4b:37:
+#                     91:9e:dc:22:e6:6d:ce:14:1a:8e:6a:cb:fe:cd:b3:
+#                     14:64:17:c7:5b:29:9e:32:bf:f2:ee:fa:d3:0b:42:
+#                     d4:ab:b7:41:32:da:0c:d4:ef:f8:81:d5:bb:8d:58:
+#                     3f:b5:1b:e8:49:28:a2:70:da:31:04:dd:f7:b2:16:
+#                     f2:4c:0a:4e:07:a8:ed:4a:3d:5e:b5:7f:a3:90:c3:
+#                     af:27
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Digital Signature, Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 03:DE:50:35:56:D1:4C:BB:66:F0:A3:E2:1B:1B:C3:97:B2:3D:D1:55
+#             X509v3 Authority Key Identifier:
+#                 keyid:03:DE:50:35:56:D1:4C:BB:66:F0:A3:E2:1B:1B:C3:97:B2:3D:D1:55
+#
+#     Signature Algorithm: sha1WithRSAEncryption
+#          cb:9c:37:aa:48:13:12:0a:fa:dd:44:9c:4f:52:b0:f4:df:ae:
+#          04:f5:79:79:08:a3:24:18:fc:4b:2b:84:c0:2d:b9:d5:c7:fe:
+#          f4:c1:1f:58:cb:b8:6d:9c:7a:74:e7:98:29:ab:11:b5:e3:70:
+#          a0:a1:cd:4c:88:99:93:8c:91:70:e2:ab:0f:1c:be:93:a9:ff:
+#          63:d5:e4:07:60:d3:a3:bf:9d:5b:09:f1:d5:8e:e3:53:f4:8e:
+#          63:fa:3f:a7:db:b4:66:df:62:66:d6:d1:6e:41:8d:f2:2d:b5:
+#          ea:77:4a:9f:9d:58:e2:2b:59:c0:40:23:ed:2d:28:82:45:3e:
+#          79:54:92:26:98:e0:80:48:a8:37:ef:f0:d6:79:60:16:de:ac:
+#          e8:0e:cd:6e:ac:44:17:38:2f:49:da:e1:45:3e:2a:b9:36:53:
+#          cf:3a:50:06:f7:2e:e8:c4:57:49:6c:61:21:18:d5:04:ad:78:
+#          3c:2c:3a:80:6b:a7:eb:af:15:14:e9:d8:89:c1:b9:38:6c:e2:
+#          91:6c:8a:ff:64:b9:77:25:57:30:c0:1b:24:a3:e1:dc:e9:df:
+#          47:7c:b5:b4:24:08:05:30:ec:2d:bd:0b:bf:45:bf:50:b9:a9:
+#          f3:eb:98:01:12:ad:c8:88:c6:98:34:5f:8d:0a:3c:c6:e9:d5:
+#          95:95:6d:de
+-----BEGIN CERTIFICATE-----
+MIIDrzCCApegAwIBAgIQCDvgVpBCRrGhdWrJWZHHSjANBgkqhkiG9w0BAQUFADBh
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSAwHgYDVQQDExdEaWdpQ2VydCBHbG9iYWwgUm9vdCBD
+QTAeFw0wNjExMTAwMDAwMDBaFw0zMTExMTAwMDAwMDBaMGExCzAJBgNVBAYTAlVT
+MRUwEwYDVQQKEwxEaWdpQ2VydCBJbmMxGTAXBgNVBAsTEHd3dy5kaWdpY2VydC5j
+b20xIDAeBgNVBAMTF0RpZ2lDZXJ0IEdsb2JhbCBSb290IENBMIIBIjANBgkqhkiG
+9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4jvhEXLeqKTTo1eqUKKPC3eQyaKl7hLOllsB
+CSDMAZOnTjC3U/dDxGkAV53ijSLdhwZAAIEJzs4bg7/fzTtxRuLWZscFs3YnFo97
+nh6Vfe63SKMI2tavegw5BmV/Sl0fvBf4q77uKNd0f3p4mVmFaG5cIzJLv07A6Fpt
+43C/dxC//AH2hdmoRBBYMql1GNXRor5H4idq9Joz+EkIYIvUX7Q6hL+hqkpMfT7P
+T19sdl6gSzeRntwi5m3OFBqOasv+zbMUZBfHWymeMr/y7vrTC0LUq7dBMtoM1O/4
+gdW7jVg/tRvoSSiicNoxBN33shbyTApOB6jtSj1etX+jkMOvJwIDAQABo2MwYTAO
+BgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQUA95QNVbR
+TLtm8KPiGxvDl7I90VUwHwYDVR0jBBgwFoAUA95QNVbRTLtm8KPiGxvDl7I90VUw
+DQYJKoZIhvcNAQEFBQADggEBAMucN6pIExIK+t1EnE9SsPTfrgT1eXkIoyQY/Esr
+hMAtudXH/vTBH1jLuG2cenTnmCmrEbXjcKChzUyImZOMkXDiqw8cvpOp/2PV5Adg
+06O/nVsJ8dWO41P0jmP6P6fbtGbfYmbW0W5BjfIttep3Sp+dWOIrWcBAI+0tKIJF
+PnlUkiaY4IBIqDfv8NZ5YBberOgOzW6sRBc4L0na4UU+Krk2U886UAb3LujEV0ls
+YSEY1QSteDwsOoBrp+uvFRTp2InBuThs4pFsiv9kuXclVzDAGySj4dzp30d8tbQk
+CAUw7C29C79Fv1C5qfPrmAESrciIxpg0X40KPMbp1ZWVbd4=
+-----END CERTIFICATE-----
+# DigiCert High Assurance EV Root CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             02:ac:5c:26:6a:0b:40:9b:8f:0b:79:f2:ae:46:25:77
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance EV Root CA
+#         Validity
+#             Not Before: Nov 10 00:00:00 2006 GMT
+#             Not After : Nov 10 00:00:00 2031 GMT
+#         Subject: C=US, O=DigiCert Inc, OU=www.digicert.com, CN=DigiCert High Assurance EV Root CA
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:c6:cc:e5:73:e6:fb:d4:bb:e5:2d:2d:32:a6:df:
+#                     e5:81:3f:c9:cd:25:49:b6:71:2a:c3:d5:94:34:67:
+#                     a2:0a:1c:b0:5f:69:a6:40:b1:c4:b7:b2:8f:d0:98:
+#                     a4:a9:41:59:3a:d3:dc:94:d6:3c:db:74:38:a4:4a:
+#                     cc:4d:25:82:f7:4a:a5:53:12:38:ee:f3:49:6d:71:
+#                     91:7e:63:b6:ab:a6:5f:c3:a4:84:f8:4f:62:51:be:
+#                     f8:c5:ec:db:38:92:e3:06:e5:08:91:0c:c4:28:41:
+#                     55:fb:cb:5a:89:15:7e:71:e8:35:bf:4d:72:09:3d:
+#                     be:3a:38:50:5b:77:31:1b:8d:b3:c7:24:45:9a:a7:
+#                     ac:6d:00:14:5a:04:b7:ba:13:eb:51:0a:98:41:41:
+#                     22:4e:65:61:87:81:41:50:a6:79:5c:89:de:19:4a:
+#                     57:d5:2e:e6:5d:1c:53:2c:7e:98:cd:1a:06:16:a4:
+#                     68:73:d0:34:04:13:5c:a1:71:d3:5a:7c:55:db:5e:
+#                     64:e1:37:87:30:56:04:e5:11:b4:29:80:12:f1:79:
+#                     39:88:a2:02:11:7c:27:66:b7:88:b7:78:f2:ca:0a:
+#                     a8:38:ab:0a:64:c2:bf:66:5d:95:84:c1:a1:25:1e:
+#                     87:5d:1a:50:0b:20:12:cc:41:bb:6e:0b:51:38:b8:
+#                     4b:cb
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Digital Signature, Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 B1:3E:C3:69:03:F8:BF:47:01:D4:98:26:1A:08:02:EF:63:64:2B:C3
+#             X509v3 Authority Key Identifier:
+#                 keyid:B1:3E:C3:69:03:F8:BF:47:01:D4:98:26:1A:08:02:EF:63:64:2B:C3
+#
+#     Signature Algorithm: sha1WithRSAEncryption
+#          1c:1a:06:97:dc:d7:9c:9f:3c:88:66:06:08:57:21:db:21:47:
+#          f8:2a:67:aa:bf:18:32:76:40:10:57:c1:8a:f3:7a:d9:11:65:
+#          8e:35:fa:9e:fc:45:b5:9e:d9:4c:31:4b:b8:91:e8:43:2c:8e:
+#          b3:78:ce:db:e3:53:79:71:d6:e5:21:94:01:da:55:87:9a:24:
+#          64:f6:8a:66:cc:de:9c:37:cd:a8:34:b1:69:9b:23:c8:9e:78:
+#          22:2b:70:43:e3:55:47:31:61:19:ef:58:c5:85:2f:4e:30:f6:
+#          a0:31:16:23:c8:e7:e2:65:16:33:cb:bf:1a:1b:a0:3d:f8:ca:
+#          5e:8b:31:8b:60:08:89:2d:0c:06:5c:52:b7:c4:f9:0a:98:d1:
+#          15:5f:9f:12:be:7c:36:63:38:bd:44:a4:7f:e4:26:2b:0a:c4:
+#          97:69:0d:e9:8c:e2:c0:10:57:b8:c8:76:12:91:55:f2:48:69:
+#          d8:bc:2a:02:5b:0f:44:d4:20:31:db:f4:ba:70:26:5d:90:60:
+#          9e:bc:4b:17:09:2f:b4:cb:1e:43:68:c9:07:27:c1:d2:5c:f7:
+#          ea:21:b9:68:12:9c:3c:9c:bf:9e:fc:80:5c:9b:63:cd:ec:47:
+#          aa:25:27:67:a0:37:f3:00:82:7d:54:d7:a9:f8:e9:2e:13:a3:
+#          77:e8:1f:4a
+-----BEGIN CERTIFICATE-----
+MIIDxTCCAq2gAwIBAgIQAqxcJmoLQJuPC3nyrkYldzANBgkqhkiG9w0BAQUFADBs
+MQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMRkwFwYDVQQLExB3
+d3cuZGlnaWNlcnQuY29tMSswKQYDVQQDEyJEaWdpQ2VydCBIaWdoIEFzc3VyYW5j
+ZSBFViBSb290IENBMB4XDTA2MTExMDAwMDAwMFoXDTMxMTExMDAwMDAwMFowbDEL
+MAkGA1UEBhMCVVMxFTATBgNVBAoTDERpZ2lDZXJ0IEluYzEZMBcGA1UECxMQd3d3
+LmRpZ2ljZXJ0LmNvbTErMCkGA1UEAxMiRGlnaUNlcnQgSGlnaCBBc3N1cmFuY2Ug
+RVYgUm9vdCBDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMbM5XPm
++9S75S0tMqbf5YE/yc0lSbZxKsPVlDRnogocsF9ppkCxxLeyj9CYpKlBWTrT3JTW
+PNt0OKRKzE0lgvdKpVMSOO7zSW1xkX5jtqumX8OkhPhPYlG++MXs2ziS4wblCJEM
+xChBVfvLWokVfnHoNb9Ncgk9vjo4UFt3MRuNs8ckRZqnrG0AFFoEt7oT61EKmEFB
+Ik5lYYeBQVCmeVyJ3hlKV9Uu5l0cUyx+mM0aBhakaHPQNAQTXKFx01p8VdteZOE3
+hzBWBOURtCmAEvF5OYiiAhF8J2a3iLd48soKqDirCmTCv2ZdlYTBoSUeh10aUAsg
+EsxBu24LUTi4S8sCAwEAAaNjMGEwDgYDVR0PAQH/BAQDAgGGMA8GA1UdEwEB/wQF
+MAMBAf8wHQYDVR0OBBYEFLE+w2kD+L9HAdSYJhoIAu9jZCvDMB8GA1UdIwQYMBaA
+FLE+w2kD+L9HAdSYJhoIAu9jZCvDMA0GCSqGSIb3DQEBBQUAA4IBAQAcGgaX3Nec
+nzyIZgYIVyHbIUf4KmeqvxgydkAQV8GK83rZEWWONfqe/EW1ntlMMUu4kehDLI6z
+eM7b41N5cdblIZQB2lWHmiRk9opmzN6cN82oNLFpmyPInngiK3BD41VHMWEZ71jF
+hS9OMPagMRYjyOfiZRYzy78aG6A9+MpeizGLYAiJLQwGXFK3xPkKmNEVX58Svnw2
+Yzi9RKR/5CYrCsSXaQ3pjOLAEFe4yHYSkVXySGnYvCoCWw9E1CAx2/S6cCZdkGCe
+vEsXCS+0yx5DaMkHJ8HSXPfqIbloEpw8nL+e/IBcm2PN7EeqJSdnoDfzAIJ9VNep
++OkuE6N36B9K
+-----END CERTIFICATE-----
+# Entrust Root Certification Authority - EC1.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             a6:8b:79:29:00:00:00:00:50:d0:91:f9
+#     Signature Algorithm: ecdsa-with-SHA384
+#         Issuer: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - EC1
+#         Validity
+#             Not Before: Dec 18 15:25:36 2012 GMT
+#             Not After : Dec 18 15:55:36 2037 GMT
+#         Subject: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2012 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - EC1
+#         Subject Public Key Info:
+#             Public Key Algorithm: id-ecPublicKey
+#                 Public-Key: (384 bit)
+#                 pub:
+#                     04:84:13:c9:d0:ba:6d:41:7b:e2:6c:d0:eb:55:5f:
+#                     66:02:1a:24:f4:5b:89:69:47:e3:b8:c2:7d:f1:f2:
+#                     02:c5:9f:a0:f6:5b:d5:8b:06:19:86:4f:53:10:6d:
+#                     07:24:27:a1:a0:f8:d5:47:19:61:4c:7d:ca:93:27:
+#                     ea:74:0c:ef:6f:96:09:fe:63:ec:70:5d:36:ad:67:
+#                     77:ae:c9:9d:7c:55:44:3a:a2:63:51:1f:f5:e3:62:
+#                     d4:a9:47:07:3e:cc:20
+#                 ASN1 OID: secp384r1
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 B7:63:E7:1A:DD:8D:E9:08:A6:55:83:A4:E0:6A:50:41:65:11:42:49
+#     Signature Algorithm: ecdsa-with-SHA384
+#          30:64:02:30:61:79:d8:e5:42:47:df:1c:ae:53:99:17:b6:6f:
+#          1c:7d:e1:bf:11:94:d1:03:88:75:e4:8d:89:a4:8a:77:46:de:
+#          6d:61:ef:02:f5:fb:b5:df:cc:fe:4e:ff:fe:a9:e6:a7:02:30:
+#          5b:99:d7:85:37:06:b5:7b:08:fd:eb:27:8b:4a:94:f9:e1:fa:
+#          a7:8e:26:08:e8:7c:92:68:6d:73:d8:6f:26:ac:21:02:b8:99:
+#          b7:26:41:5b:25:60:ae:d0:48:1a:ee:06
+-----BEGIN CERTIFICATE-----
+MIIC+TCCAoCgAwIBAgINAKaLeSkAAAAAUNCR+TAKBggqhkjOPQQDAzCBvzELMAkG
+A1UEBhMCVVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xKDAmBgNVBAsTH1NlZSB3
+d3cuZW50cnVzdC5uZXQvbGVnYWwtdGVybXMxOTA3BgNVBAsTMChjKSAyMDEyIEVu
+dHJ1c3QsIEluYy4gLSBmb3IgYXV0aG9yaXplZCB1c2Ugb25seTEzMDEGA1UEAxMq
+RW50cnVzdCBSb290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5IC0gRUMxMB4XDTEy
+MTIxODE1MjUzNloXDTM3MTIxODE1NTUzNlowgb8xCzAJBgNVBAYTAlVTMRYwFAYD
+VQQKEw1FbnRydXN0LCBJbmMuMSgwJgYDVQQLEx9TZWUgd3d3LmVudHJ1c3QubmV0
+L2xlZ2FsLXRlcm1zMTkwNwYDVQQLEzAoYykgMjAxMiBFbnRydXN0LCBJbmMuIC0g
+Zm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxMzAxBgNVBAMTKkVudHJ1c3QgUm9vdCBD
+ZXJ0aWZpY2F0aW9uIEF1dGhvcml0eSAtIEVDMTB2MBAGByqGSM49AgEGBSuBBAAi
+A2IABIQTydC6bUF74mzQ61VfZgIaJPRbiWlH47jCffHyAsWfoPZb1YsGGYZPUxBt
+ByQnoaD41UcZYUx9ypMn6nQM72+WCf5j7HBdNq1nd67JnXxVRDqiY1Ef9eNi1KlH
+Bz7MIKNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0O
+BBYEFLdj5xrdjekIplWDpOBqUEFlEUJJMAoGCCqGSM49BAMDA2cAMGQCMGF52OVC
+R98crlOZF7ZvHH3hvxGU0QOIdeSNiaSKd0bebWHvAvX7td/M/k7//qnmpwIwW5nX
+hTcGtXsI/esni0qU+eH6p44mCOh8kmhtc9hvJqwhAriZtyZBWyVgrtBIGu4G
+-----END CERTIFICATE-----
+# Entrust Root Certification Authority - G2.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 1246989352 (0x4a538c28)
+#     Signature Algorithm: sha256WithRSAEncryption
+#         Issuer: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2009 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - G2
+#         Validity
+#             Not Before: Jul  7 17:25:54 2009 GMT
+#             Not After : Dec  7 17:55:54 2030 GMT
+#         Subject: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2009 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - G2
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:ba:84:b6:72:db:9e:0c:6b:e2:99:e9:30:01:a7:
+#                     76:ea:32:b8:95:41:1a:c9:da:61:4e:58:72:cf:fe:
+#                     f6:82:79:bf:73:61:06:0a:a5:27:d8:b3:5f:d3:45:
+#                     4e:1c:72:d6:4e:32:f2:72:8a:0f:f7:83:19:d0:6a:
+#                     80:80:00:45:1e:b0:c7:e7:9a:bf:12:57:27:1c:a3:
+#                     68:2f:0a:87:bd:6a:6b:0e:5e:65:f3:1c:77:d5:d4:
+#                     85:8d:70:21:b4:b3:32:e7:8b:a2:d5:86:39:02:b1:
+#                     b8:d2:47:ce:e4:c9:49:c4:3b:a7:de:fb:54:7d:57:
+#                     be:f0:e8:6e:c2:79:b2:3a:0b:55:e2:50:98:16:32:
+#                     13:5c:2f:78:56:c1:c2:94:b3:f2:5a:e4:27:9a:9f:
+#                     24:d7:c6:ec:d0:9b:25:82:e3:cc:c2:c4:45:c5:8c:
+#                     97:7a:06:6b:2a:11:9f:a9:0a:6e:48:3b:6f:db:d4:
+#                     11:19:42:f7:8f:07:bf:f5:53:5f:9c:3e:f4:17:2c:
+#                     e6:69:ac:4e:32:4c:62:77:ea:b7:e8:e5:bb:34:bc:
+#                     19:8b:ae:9c:51:e7:b7:7e:b5:53:b1:33:22:e5:6d:
+#                     cf:70:3c:1a:fa:e2:9b:67:b6:83:f4:8d:a5:af:62:
+#                     4c:4d:e0:58:ac:64:34:12:03:f8:b6:8d:94:63:24:
+#                     a4:71
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 6A:72:26:7A:D0:1E:EF:7D:E7:3B:69:51:D4:6C:8D:9F:90:12:66:AB
+#     Signature Algorithm: sha256WithRSAEncryption
+#          79:9f:1d:96:c6:b6:79:3f:22:8d:87:d3:87:03:04:60:6a:6b:
+#          9a:2e:59:89:73:11:ac:43:d1:f5:13:ff:8d:39:2b:c0:f2:bd:
+#          4f:70:8c:a9:2f:ea:17:c4:0b:54:9e:d4:1b:96:98:33:3c:a8:
+#          ad:62:a2:00:76:ab:59:69:6e:06:1d:7e:c4:b9:44:8d:98:af:
+#          12:d4:61:db:0a:19:46:47:f3:eb:f7:63:c1:40:05:40:a5:d2:
+#          b7:f4:b5:9a:36:bf:a9:88:76:88:04:55:04:2b:9c:87:7f:1a:
+#          37:3c:7e:2d:a5:1a:d8:d4:89:5e:ca:bd:ac:3d:6c:d8:6d:af:
+#          d5:f3:76:0f:cd:3b:88:38:22:9d:6c:93:9a:c4:3d:bf:82:1b:
+#          65:3f:a6:0f:5d:aa:fc:e5:b2:15:ca:b5:ad:c6:bc:3d:d0:84:
+#          e8:ea:06:72:b0:4d:39:32:78:bf:3e:11:9c:0b:a4:9d:9a:21:
+#          f3:f0:9b:0b:30:78:db:c1:dc:87:43:fe:bc:63:9a:ca:c5:c2:
+#          1c:c9:c7:8d:ff:3b:12:58:08:e6:b6:3d:ec:7a:2c:4e:fb:83:
+#          96:ce:0c:3c:69:87:54:73:a4:73:c2:93:ff:51:10:ac:15:54:
+#          01:d8:fc:05:b1:89:a1:7f:74:83:9a:49:d7:dc:4e:7b:8a:48:
+#          6f:8b:45:f6
+-----BEGIN CERTIFICATE-----
+MIIEPjCCAyagAwIBAgIESlOMKDANBgkqhkiG9w0BAQsFADCBvjELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xKDAmBgNVBAsTH1NlZSB3d3cuZW50
+cnVzdC5uZXQvbGVnYWwtdGVybXMxOTA3BgNVBAsTMChjKSAyMDA5IEVudHJ1c3Qs
+IEluYy4gLSBmb3IgYXV0aG9yaXplZCB1c2Ugb25seTEyMDAGA1UEAxMpRW50cnVz
+dCBSb290IENlcnRpZmljYXRpb24gQXV0aG9yaXR5IC0gRzIwHhcNMDkwNzA3MTcy
+NTU0WhcNMzAxMjA3MTc1NTU0WjCBvjELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUVu
+dHJ1c3QsIEluYy4xKDAmBgNVBAsTH1NlZSB3d3cuZW50cnVzdC5uZXQvbGVnYWwt
+dGVybXMxOTA3BgNVBAsTMChjKSAyMDA5IEVudHJ1c3QsIEluYy4gLSBmb3IgYXV0
+aG9yaXplZCB1c2Ugb25seTEyMDAGA1UEAxMpRW50cnVzdCBSb290IENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5IC0gRzIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
+AoIBAQC6hLZy254Ma+KZ6TABp3bqMriVQRrJ2mFOWHLP/vaCeb9zYQYKpSfYs1/T
+RU4cctZOMvJyig/3gxnQaoCAAEUesMfnmr8SVycco2gvCoe9amsOXmXzHHfV1IWN
+cCG0szLni6LVhjkCsbjSR87kyUnEO6fe+1R9V77w6G7CebI6C1XiUJgWMhNcL3hW
+wcKUs/Ja5CeanyTXxuzQmyWC48zCxEXFjJd6BmsqEZ+pCm5IO2/b1BEZQvePB7/1
+U1+cPvQXLOZprE4yTGJ36rfo5bs0vBmLrpxR57d+tVOxMyLlbc9wPBr64ptntoP0
+jaWvYkxN4FisZDQSA/i2jZRjJKRxAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAP
+BgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRqciZ60B7vfec7aVHUbI2fkBJmqzAN
+BgkqhkiG9w0BAQsFAAOCAQEAeZ8dlsa2eT8ijYfThwMEYGprmi5ZiXMRrEPR9RP/
+jTkrwPK9T3CMqS/qF8QLVJ7UG5aYMzyorWKiAHarWWluBh1+xLlEjZivEtRh2woZ
+Rkfz6/djwUAFQKXSt/S1mja/qYh2iARVBCuch38aNzx+LaUa2NSJXsq9rD1s2G2v
+1fN2D807iDginWyTmsQ9v4IbZT+mD12q/OWyFcq1rca8PdCE6OoGcrBNOTJ4vz4R
+nAuknZoh8/CbCzB428Hch0P+vGOaysXCHMnHjf87ElgI5rY97HosTvuDls4MPGmH
+VHOkc8KT/1EQrBVUAdj8BbGJoX90g5pJ19xOe4pIb4tF9g==
+-----END CERTIFICATE-----
+# Entrust Root Certification Authority.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 1164660820 (0x456b5054)
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=Entrust, Inc., OU=www.entrust.net/CPS is incorporated by reference, OU=(c) 2006 Entrust, Inc., CN=Entrust Root Certification Authority
+#         Validity
+#             Not Before: Nov 27 20:23:42 2006 GMT
+#             Not After : Nov 27 20:53:42 2026 GMT
+#         Subject: C=US, O=Entrust, Inc., OU=www.entrust.net/CPS is incorporated by reference, OU=(c) 2006 Entrust, Inc., CN=Entrust Root Certification Authority
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:b6:95:b6:43:42:fa:c6:6d:2a:6f:48:df:94:4c:
+#                     39:57:05:ee:c3:79:11:41:68:36:ed:ec:fe:9a:01:
+#                     8f:a1:38:28:fc:f7:10:46:66:2e:4d:1e:1a:b1:1a:
+#                     4e:c6:d1:c0:95:88:b0:c9:ff:31:8b:33:03:db:b7:
+#                     83:7b:3e:20:84:5e:ed:b2:56:28:a7:f8:e0:b9:40:
+#                     71:37:c5:cb:47:0e:97:2a:68:c0:22:95:62:15:db:
+#                     47:d9:f5:d0:2b:ff:82:4b:c9:ad:3e:de:4c:db:90:
+#                     80:50:3f:09:8a:84:00:ec:30:0a:3d:18:cd:fb:fd:
+#                     2a:59:9a:23:95:17:2c:45:9e:1f:6e:43:79:6d:0c:
+#                     5c:98:fe:48:a7:c5:23:47:5c:5e:fd:6e:e7:1e:b4:
+#                     f6:68:45:d1:86:83:5b:a2:8a:8d:b1:e3:29:80:fe:
+#                     25:71:88:ad:be:bc:8f:ac:52:96:4b:aa:51:8d:e4:
+#                     13:31:19:e8:4e:4d:9f:db:ac:b3:6a:d5:bc:39:54:
+#                     71:ca:7a:7a:7f:90:dd:7d:1d:80:d9:81:bb:59:26:
+#                     c2:11:fe:e6:93:e2:f7:80:e4:65:fb:34:37:0e:29:
+#                     80:70:4d:af:38:86:2e:9e:7f:57:af:9e:17:ae:eb:
+#                     1c:cb:28:21:5f:b6:1c:d8:e7:a2:04:22:f9:d3:da:
+#                     d8:cb
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Private Key Usage Period:
+#                 Not Before: Nov 27 20:23:42 2006 GMT, Not After: Nov 27 20:53:42 2026 GMT
+#             X509v3 Authority Key Identifier:
+#                 keyid:68:90:E4:67:A4:A6:53:80:C7:86:66:A4:F1:F7:4B:43:FB:84:BD:6D
+#
+#             X509v3 Subject Key Identifier:
+#                 68:90:E4:67:A4:A6:53:80:C7:86:66:A4:F1:F7:4B:43:FB:84:BD:6D
+#             1.2.840.113533.7.65.0:
+#                 0...V7.1:4.0....
+#     Signature Algorithm: sha1WithRSAEncryption
+#          93:d4:30:b0:d7:03:20:2a:d0:f9:63:e8:91:0c:05:20:a9:5f:
+#          19:ca:7b:72:4e:d4:b1:db:d0:96:fb:54:5a:19:2c:0c:08:f7:
+#          b2:bc:85:a8:9d:7f:6d:3b:52:b3:2a:db:e7:d4:84:8c:63:f6:
+#          0f:cb:26:01:91:50:6c:f4:5f:14:e2:93:74:c0:13:9e:30:3a:
+#          50:e3:b4:60:c5:1c:f0:22:44:8d:71:47:ac:c8:1a:c9:e9:9b:
+#          9a:00:60:13:ff:70:7e:5f:11:4d:49:1b:b3:15:52:7b:c9:54:
+#          da:bf:9d:95:af:6b:9a:d8:9e:e9:f1:e4:43:8d:e2:11:44:3a:
+#          bf:af:bd:83:42:73:52:8b:aa:bb:a7:29:cf:f5:64:1c:0a:4d:
+#          d1:bc:aa:ac:9f:2a:d0:ff:7f:7f:da:7d:ea:b1:ed:30:25:c1:
+#          84:da:34:d2:5b:78:83:56:ec:9c:36:c3:26:e2:11:f6:67:49:
+#          1d:92:ab:8c:fb:eb:ff:7a:ee:85:4a:a7:50:80:f0:a7:5c:4a:
+#          94:2e:5f:05:99:3c:52:41:e0:cd:b4:63:cf:01:43:ba:9c:83:
+#          dc:8f:60:3b:f3:5a:b4:b4:7b:ae:da:0b:90:38:75:ef:81:1d:
+#          66:d2:f7:57:70:36:b3:bf:fc:28:af:71:25:85:5b:13:fe:1e:
+#          7f:5a:b4:3c
+-----BEGIN CERTIFICATE-----
+MIIEkTCCA3mgAwIBAgIERWtQVDANBgkqhkiG9w0BAQUFADCBsDELMAkGA1UEBhMC
+VVMxFjAUBgNVBAoTDUVudHJ1c3QsIEluYy4xOTA3BgNVBAsTMHd3dy5lbnRydXN0
+Lm5ldC9DUFMgaXMgaW5jb3Jwb3JhdGVkIGJ5IHJlZmVyZW5jZTEfMB0GA1UECxMW
+KGMpIDIwMDYgRW50cnVzdCwgSW5jLjEtMCsGA1UEAxMkRW50cnVzdCBSb290IENl
+cnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA2MTEyNzIwMjM0MloXDTI2MTEyNzIw
+NTM0MlowgbAxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1FbnRydXN0LCBJbmMuMTkw
+NwYDVQQLEzB3d3cuZW50cnVzdC5uZXQvQ1BTIGlzIGluY29ycG9yYXRlZCBieSBy
+ZWZlcmVuY2UxHzAdBgNVBAsTFihjKSAyMDA2IEVudHJ1c3QsIEluYy4xLTArBgNV
+BAMTJEVudHJ1c3QgUm9vdCBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASIwDQYJ
+KoZIhvcNAQEBBQADggEPADCCAQoCggEBALaVtkNC+sZtKm9I35RMOVcF7sN5EUFo
+Nu3s/poBj6E4KPz3EEZmLk0eGrEaTsbRwJWIsMn/MYszA9u3g3s+IIRe7bJWKKf4
+4LlAcTfFy0cOlypowCKVYhXbR9n10Cv/gkvJrT7eTNuQgFA/CYqEAOwwCj0Yzfv9
+KlmaI5UXLEWeH25DeW0MXJj+SKfFI0dcXv1u5x609mhF0YaDW6KKjbHjKYD+JXGI
+rb68j6xSlkuqUY3kEzEZ6E5Nn9uss2rVvDlUccp6en+Q3X0dgNmBu1kmwhH+5pPi
+94DkZfs0Nw4pgHBNrziGLp5/V6+eF67rHMsoIV+2HNjnogQi+dPa2MsCAwEAAaOB
+sDCBrTAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zArBgNVHRAEJDAi
+gA8yMDA2MTEyNzIwMjM0MlqBDzIwMjYxMTI3MjA1MzQyWjAfBgNVHSMEGDAWgBRo
+kORnpKZTgMeGZqTx90tD+4S9bTAdBgNVHQ4EFgQUaJDkZ6SmU4DHhmak8fdLQ/uE
+vW0wHQYJKoZIhvZ9B0EABBAwDhsIVjcuMTo0LjADAgSQMA0GCSqGSIb3DQEBBQUA
+A4IBAQCT1DCw1wMgKtD5Y+iRDAUgqV8ZyntyTtSx29CW+1RaGSwMCPeyvIWonX9t
+O1KzKtvn1ISMY/YPyyYBkVBs9F8U4pN0wBOeMDpQ47RgxRzwIkSNcUesyBrJ6Zua
+AGAT/3B+XxFNSRuzFVJ7yVTav52Vr2ua2J7p8eRDjeIRRDq/r72DQnNSi6q7pynP
+9WQcCk3RvKqsnyrQ/39/2n3qse0wJcGE2jTSW3iDVuycNsMm4hH2Z0kdkquM++v/
+eu6FSqdQgPCnXEqULl8FmTxSQeDNtGPPAUO6nIPcj2A781q0tHuu2guQOHXvgR1m
+0vdXcDazv/wor3ElhVsT/h5/WrQ8
+-----END CERTIFICATE-----
+# Entrust.net Certification Authority (2048).pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 946069240 (0x3863def8)
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: O=Entrust.net, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), OU=(c) 1999 Entrust.net Limited, CN=Entrust.net Certification Authority (2048)
+#         Validity
+#             Not Before: Dec 24 17:50:51 1999 GMT
+#             Not After : Jul 24 14:15:12 2029 GMT
+#         Subject: O=Entrust.net, OU=www.entrust.net/CPS_2048 incorp. by ref. (limits liab.), OU=(c) 1999 Entrust.net Limited, CN=Entrust.net Certification Authority (2048)
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:ad:4d:4b:a9:12:86:b2:ea:a3:20:07:15:16:64:
+#                     2a:2b:4b:d1:bf:0b:4a:4d:8e:ed:80:76:a5:67:b7:
+#                     78:40:c0:73:42:c8:68:c0:db:53:2b:dd:5e:b8:76:
+#                     98:35:93:8b:1a:9d:7c:13:3a:0e:1f:5b:b7:1e:cf:
+#                     e5:24:14:1e:b1:81:a9:8d:7d:b8:cc:6b:4b:03:f1:
+#                     02:0c:dc:ab:a5:40:24:00:7f:74:94:a1:9d:08:29:
+#                     b3:88:0b:f5:87:77:9d:55:cd:e4:c3:7e:d7:6a:64:
+#                     ab:85:14:86:95:5b:97:32:50:6f:3d:c8:ba:66:0c:
+#                     e3:fc:bd:b8:49:c1:76:89:49:19:fd:c0:a8:bd:89:
+#                     a3:67:2f:c6:9f:bc:71:19:60:b8:2d:e9:2c:c9:90:
+#                     76:66:7b:94:e2:af:78:d6:65:53:5d:3c:d6:9c:b2:
+#                     cf:29:03:f9:2f:a4:50:b2:d4:48:ce:05:32:55:8a:
+#                     fd:b2:64:4c:0e:e4:98:07:75:db:7f:df:b9:08:55:
+#                     60:85:30:29:f9:7b:48:a4:69:86:e3:35:3f:1e:86:
+#                     5d:7a:7a:15:bd:ef:00:8e:15:22:54:17:00:90:26:
+#                     93:bc:0e:49:68:91:bf:f8:47:d3:9d:95:42:c1:0e:
+#                     4d:df:6f:26:cf:c3:18:21:62:66:43:70:d6:d5:c0:
+#                     07:e1
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 55:E4:81:D1:11:80:BE:D8:89:B9:08:A3:31:F9:A1:24:09:16:B9:70
+#     Signature Algorithm: sha1WithRSAEncryption
+#          3b:9b:8f:56:9b:30:e7:53:99:7c:7a:79:a7:4d:97:d7:19:95:
+#          90:fb:06:1f:ca:33:7c:46:63:8f:96:66:24:fa:40:1b:21:27:
+#          ca:e6:72:73:f2:4f:fe:31:99:fd:c8:0c:4c:68:53:c6:80:82:
+#          13:98:fa:b6:ad:da:5d:3d:f1:ce:6e:f6:15:11:94:82:0c:ee:
+#          3f:95:af:11:ab:0f:d7:2f:de:1f:03:8f:57:2c:1e:c9:bb:9a:
+#          1a:44:95:eb:18:4f:a6:1f:cd:7d:57:10:2f:9b:04:09:5a:84:
+#          b5:6e:d8:1d:3a:e1:d6:9e:d1:6c:79:5e:79:1c:14:c5:e3:d0:
+#          4c:93:3b:65:3c:ed:df:3d:be:a6:e5:95:1a:c3:b5:19:c3:bd:
+#          5e:5b:bb:ff:23:ef:68:19:cb:12:93:27:5c:03:2d:6f:30:d0:
+#          1e:b6:1a:ac:de:5a:f7:d1:aa:a8:27:a6:fe:79:81:c4:79:99:
+#          33:57:ba:12:b0:a9:e0:42:6c:93:ca:56:de:fe:6d:84:0b:08:
+#          8b:7e:8d:ea:d7:98:21:c6:f3:e7:3c:79:2f:5e:9c:d1:4c:15:
+#          8d:e1:ec:22:37:cc:9a:43:0b:97:dc:80:90:8d:b3:67:9b:6f:
+#          48:08:15:56:cf:bf:f1:2b:7c:5e:9a:76:e9:59:90:c5:7c:83:
+#          35:11:65:51
+-----BEGIN CERTIFICATE-----
+MIIEKjCCAxKgAwIBAgIEOGPe+DANBgkqhkiG9w0BAQUFADCBtDEUMBIGA1UEChML
+RW50cnVzdC5uZXQxQDA+BgNVBAsUN3d3dy5lbnRydXN0Lm5ldC9DUFNfMjA0OCBp
+bmNvcnAuIGJ5IHJlZi4gKGxpbWl0cyBsaWFiLikxJTAjBgNVBAsTHChjKSAxOTk5
+IEVudHJ1c3QubmV0IExpbWl0ZWQxMzAxBgNVBAMTKkVudHJ1c3QubmV0IENlcnRp
+ZmljYXRpb24gQXV0aG9yaXR5ICgyMDQ4KTAeFw05OTEyMjQxNzUwNTFaFw0yOTA3
+MjQxNDE1MTJaMIG0MRQwEgYDVQQKEwtFbnRydXN0Lm5ldDFAMD4GA1UECxQ3d3d3
+LmVudHJ1c3QubmV0L0NQU18yMDQ4IGluY29ycC4gYnkgcmVmLiAobGltaXRzIGxp
+YWIuKTElMCMGA1UECxMcKGMpIDE5OTkgRW50cnVzdC5uZXQgTGltaXRlZDEzMDEG
+A1UEAxMqRW50cnVzdC5uZXQgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgKDIwNDgp
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEArU1LqRKGsuqjIAcVFmQq
+K0vRvwtKTY7tgHalZ7d4QMBzQshowNtTK91euHaYNZOLGp18EzoOH1u3Hs/lJBQe
+sYGpjX24zGtLA/ECDNyrpUAkAH90lKGdCCmziAv1h3edVc3kw37XamSrhRSGlVuX
+MlBvPci6Zgzj/L24ScF2iUkZ/cCovYmjZy/Gn7xxGWC4LeksyZB2ZnuU4q941mVT
+XTzWnLLPKQP5L6RQstRIzgUyVYr9smRMDuSYB3Xbf9+5CFVghTAp+XtIpGmG4zU/
+HoZdenoVve8AjhUiVBcAkCaTvA5JaJG/+EfTnZVCwQ5N328mz8MYIWJmQ3DW1cAH
+4QIDAQABo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNV
+HQ4EFgQUVeSB0RGAvtiJuQijMfmhJAkWuXAwDQYJKoZIhvcNAQEFBQADggEBADub
+j1abMOdTmXx6eadNl9cZlZD7Bh/KM3xGY4+WZiT6QBshJ8rmcnPyT/4xmf3IDExo
+U8aAghOY+rat2l098c5u9hURlIIM7j+VrxGrD9cv3h8Dj1csHsm7mhpElesYT6Yf
+zX1XEC+bBAlahLVu2B064dae0Wx5XnkcFMXj0EyTO2U87d89vqbllRrDtRnDvV5b
+u/8j72gZyxKTJ1wDLW8w0B62GqzeWvfRqqgnpv55gcR5mTNXuhKwqeBCbJPKVt7+
+bYQLCIt+jerXmCHG8+c8eS9enNFMFY3h7CI3zJpDC5fcgJCNs2ebb0gIFVbPv/Er
+fF6adulZkMV8gzURZVE=
+-----END CERTIFICATE-----
+# GeoTrust Global CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 144470 (0x23456)
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=GeoTrust Inc., CN=GeoTrust Global CA
+#         Validity
+#             Not Before: May 21 04:00:00 2002 GMT
+#             Not After : May 21 04:00:00 2022 GMT
+#         Subject: C=US, O=GeoTrust Inc., CN=GeoTrust Global CA
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:da:cc:18:63:30:fd:f4:17:23:1a:56:7e:5b:df:
+#                     3c:6c:38:e4:71:b7:78:91:d4:bc:a1:d8:4c:f8:a8:
+#                     43:b6:03:e9:4d:21:07:08:88:da:58:2f:66:39:29:
+#                     bd:05:78:8b:9d:38:e8:05:b7:6a:7e:71:a4:e6:c4:
+#                     60:a6:b0:ef:80:e4:89:28:0f:9e:25:d6:ed:83:f3:
+#                     ad:a6:91:c7:98:c9:42:18:35:14:9d:ad:98:46:92:
+#                     2e:4f:ca:f1:87:43:c1:16:95:57:2d:50:ef:89:2d:
+#                     80:7a:57:ad:f2:ee:5f:6b:d2:00:8d:b9:14:f8:14:
+#                     15:35:d9:c0:46:a3:7b:72:c8:91:bf:c9:55:2b:cd:
+#                     d0:97:3e:9c:26:64:cc:df:ce:83:19:71:ca:4e:e6:
+#                     d4:d5:7b:a9:19:cd:55:de:c8:ec:d2:5e:38:53:e5:
+#                     5c:4f:8c:2d:fe:50:23:36:fc:66:e6:cb:8e:a4:39:
+#                     19:00:b7:95:02:39:91:0b:0e:fe:38:2e:d1:1d:05:
+#                     9a:f6:4d:3e:6f:0f:07:1d:af:2c:1e:8f:60:39:e2:
+#                     fa:36:53:13:39:d4:5e:26:2b:db:3d:a8:14:bd:32:
+#                     eb:18:03:28:52:04:71:e5:ab:33:3d:e1:38:bb:07:
+#                     36:84:62:9c:79:ea:16:30:f4:5f:c0:2b:e8:71:6b:
+#                     e4:f9
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Subject Key Identifier:
+#                 C0:7A:98:68:8D:89:FB:AB:05:64:0C:11:7D:AA:7D:65:B8:CA:CC:4E
+#             X509v3 Authority Key Identifier:
+#                 keyid:C0:7A:98:68:8D:89:FB:AB:05:64:0C:11:7D:AA:7D:65:B8:CA:CC:4E
+#
+#     Signature Algorithm: sha1WithRSAEncryption
+#          35:e3:29:6a:e5:2f:5d:54:8e:29:50:94:9f:99:1a:14:e4:8f:
+#          78:2a:62:94:a2:27:67:9e:d0:cf:1a:5e:47:e9:c1:b2:a4:cf:
+#          dd:41:1a:05:4e:9b:4b:ee:4a:6f:55:52:b3:24:a1:37:0a:eb:
+#          64:76:2a:2e:2c:f3:fd:3b:75:90:bf:fa:71:d8:c7:3d:37:d2:
+#          b5:05:95:62:b9:a6:de:89:3d:36:7b:38:77:48:97:ac:a6:20:
+#          8f:2e:a6:c9:0c:c2:b2:99:45:00:c7:ce:11:51:22:22:e0:a5:
+#          ea:b6:15:48:09:64:ea:5e:4f:74:f7:05:3e:c7:8a:52:0c:db:
+#          15:b4:bd:6d:9b:e5:c6:b1:54:68:a9:e3:69:90:b6:9a:a5:0f:
+#          b8:b9:3f:20:7d:ae:4a:b5:b8:9c:e4:1d:b6:ab:e6:94:a5:c1:
+#          c7:83:ad:db:f5:27:87:0e:04:6c:d5:ff:dd:a0:5d:ed:87:52:
+#          b7:2b:15:02:ae:39:a6:6a:74:e9:da:c4:e7:bc:4d:34:1e:a9:
+#          5c:4d:33:5f:92:09:2f:88:66:5d:77:97:c7:1d:76:13:a9:d5:
+#          e5:f1:16:09:11:35:d5:ac:db:24:71:70:2c:98:56:0b:d9:17:
+#          b4:d1:e3:51:2b:5e:75:e8:d5:d0:dc:4f:34:ed:c2:05:66:80:
+#          a1:cb:e6:33
+-----BEGIN CERTIFICATE-----
+MIIDVDCCAjygAwIBAgIDAjRWMA0GCSqGSIb3DQEBBQUAMEIxCzAJBgNVBAYTAlVT
+MRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMRswGQYDVQQDExJHZW9UcnVzdCBHbG9i
+YWwgQ0EwHhcNMDIwNTIxMDQwMDAwWhcNMjIwNTIxMDQwMDAwWjBCMQswCQYDVQQG
+EwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjEbMBkGA1UEAxMSR2VvVHJ1c3Qg
+R2xvYmFsIENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2swYYzD9
+9BcjGlZ+W988bDjkcbd4kdS8odhM+KhDtgPpTSEHCIjaWC9mOSm9BXiLnTjoBbdq
+fnGk5sRgprDvgOSJKA+eJdbtg/OtppHHmMlCGDUUna2YRpIuT8rxh0PBFpVXLVDv
+iS2Aelet8u5fa9IAjbkU+BQVNdnARqN7csiRv8lVK83Qlz6cJmTM386DGXHKTubU
+1XupGc1V3sjs0l44U+VcT4wt/lAjNvxm5suOpDkZALeVAjmRCw7+OC7RHQWa9k0+
+bw8HHa8sHo9gOeL6NlMTOdReJivbPagUvTLrGAMoUgRx5aszPeE4uwc2hGKceeoW
+MPRfwCvocWvk+QIDAQABo1MwUTAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBTA
+ephojYn7qwVkDBF9qn1luMrMTjAfBgNVHSMEGDAWgBTAephojYn7qwVkDBF9qn1l
+uMrMTjANBgkqhkiG9w0BAQUFAAOCAQEANeMpauUvXVSOKVCUn5kaFOSPeCpilKIn
+Z57QzxpeR+nBsqTP3UEaBU6bS+5Kb1VSsyShNwrrZHYqLizz/Tt1kL/6cdjHPTfS
+tQWVYrmm3ok9Nns4d0iXrKYgjy6myQzCsplFAMfOEVEiIuCl6rYVSAlk6l5PdPcF
+PseKUgzbFbS9bZvlxrFUaKnjaZC2mqUPuLk/IH2uSrW4nOQdtqvmlKXBx4Ot2/Un
+hw4EbNX/3aBd7YdStysVAq45pmp06drE57xNNB6pXE0zX5IJL4hmXXeXxx12E6nV
+5fEWCRE11azbJHFwLJhWC9kXtNHjUStedejV0NxPNO3CBWaAocvmMw==
+-----END CERTIFICATE-----
+# GeoTrust Primary Certification Authority - G2.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             3c:b2:f4:48:0a:00:e2:fe:eb:24:3b:5e:60:3e:c3:6b
+#     Signature Algorithm: ecdsa-with-SHA384
+#         Issuer: C=US, O=GeoTrust Inc., OU=(c) 2007 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G2
+#         Validity
+#             Not Before: Nov  5 00:00:00 2007 GMT
+#             Not After : Jan 18 23:59:59 2038 GMT
+#         Subject: C=US, O=GeoTrust Inc., OU=(c) 2007 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G2
+#         Subject Public Key Info:
+#             Public Key Algorithm: id-ecPublicKey
+#                 Public-Key: (384 bit)
+#                 pub:
+#                     04:15:b1:e8:fd:03:15:43:e5:ac:eb:87:37:11:62:
+#                     ef:d2:83:36:52:7d:45:57:0b:4a:8d:7b:54:3b:3a:
+#                     6e:5f:15:02:c0:50:a6:cf:25:2f:7d:ca:48:b8:c7:
+#                     50:63:1c:2a:21:08:7c:9a:36:d8:0b:fe:d1:26:c5:
+#                     58:31:30:28:25:f3:5d:5d:a3:b8:b6:a5:b4:92:ed:
+#                     6c:2c:9f:eb:dd:43:89:a2:3c:4b:48:91:1d:50:ec:
+#                     26:df:d6:60:2e:bd:21
+#                 ASN1 OID: secp384r1
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 15:5F:35:57:51:55:FB:25:B2:AD:03:69:FC:01:A3:FA:BE:11:55:D5
+#     Signature Algorithm: ecdsa-with-SHA384
+#          30:64:02:30:64:96:59:a6:e8:09:de:8b:ba:fa:5a:88:88:f0:
+#          1f:91:d3:46:a8:f2:4a:4c:02:63:fb:6c:5f:38:db:2e:41:93:
+#          a9:0e:e6:9d:dc:31:1c:b2:a0:a7:18:1c:79:e1:c7:36:02:30:
+#          3a:56:af:9a:74:6c:f6:fb:83:e0:33:d3:08:5f:a1:9c:c2:5b:
+#          9f:46:d6:b6:cb:91:06:63:a2:06:e7:33:ac:3e:a8:81:12:d0:
+#          cb:ba:d0:92:0b:b6:9e:96:aa:04:0f:8a
+-----BEGIN CERTIFICATE-----
+MIICrjCCAjWgAwIBAgIQPLL0SAoA4v7rJDteYD7DazAKBggqhkjOPQQDAzCBmDEL
+MAkGA1UEBhMCVVMxFjAUBgNVBAoTDUdlb1RydXN0IEluYy4xOTA3BgNVBAsTMChj
+KSAyMDA3IEdlb1RydXN0IEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25seTE2
+MDQGA1UEAxMtR2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0
+eSAtIEcyMB4XDTA3MTEwNTAwMDAwMFoXDTM4MDExODIzNTk1OVowgZgxCzAJBgNV
+BAYTAlVTMRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMTkwNwYDVQQLEzAoYykgMjAw
+NyBHZW9UcnVzdCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxNjA0BgNV
+BAMTLUdlb1RydXN0IFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBH
+MjB2MBAGByqGSM49AgEGBSuBBAAiA2IABBWx6P0DFUPlrOuHNxFi79KDNlJ9RVcL
+So17VDs6bl8VAsBQps8lL33KSLjHUGMcKiEIfJo22Av+0SbFWDEwKCXzXV2juLal
+tJLtbCyf691DiaI8S0iRHVDsJt/WYC69IaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAO
+BgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYEFBVfNVdRVfslsq0DafwBo/q+EVXVMAoG
+CCqGSM49BAMDA2cAMGQCMGSWWaboCd6LuvpaiIjwH5HTRqjySkwCY/tsXzjbLkGT
+qQ7mndwxHLKgpxgceeHHNgIwOlavmnRs9vuD4DPTCF+hnMJbn0bWtsuRBmOiBucz
+rD6ogRLQy7rQkgu2npaqBA+K
+-----END CERTIFICATE-----
+# GeoTrust Primary Certification Authority - G3.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             15:ac:6e:94:19:b2:79:4b:41:f6:27:a9:c3:18:0f:1f
+#     Signature Algorithm: sha256WithRSAEncryption
+#         Issuer: C=US, O=GeoTrust Inc., OU=(c) 2008 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G3
+#         Validity
+#             Not Before: Apr  2 00:00:00 2008 GMT
+#             Not After : Dec  1 23:59:59 2037 GMT
+#         Subject: C=US, O=GeoTrust Inc., OU=(c) 2008 GeoTrust Inc. - For authorized use only, CN=GeoTrust Primary Certification Authority - G3
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:dc:e2:5e:62:58:1d:33:57:39:32:33:fa:eb:cb:
+#                     87:8c:a7:d4:4a:dd:06:88:ea:64:8e:31:98:a5:38:
+#                     90:1e:98:cf:2e:63:2b:f0:46:bc:44:b2:89:a1:c0:
+#                     28:0c:49:70:21:95:9f:64:c0:a6:93:12:02:65:26:
+#                     86:c6:a5:89:f0:fa:d7:84:a0:70:af:4f:1a:97:3f:
+#                     06:44:d5:c9:eb:72:10:7d:e4:31:28:fb:1c:61:e6:
+#                     28:07:44:73:92:22:69:a7:03:88:6c:9d:63:c8:52:
+#                     da:98:27:e7:08:4c:70:3e:b4:c9:12:c1:c5:67:83:
+#                     5d:33:f3:03:11:ec:6a:d0:53:e2:d1:ba:36:60:94:
+#                     80:bb:61:63:6c:5b:17:7e:df:40:94:1e:ab:0d:c2:
+#                     21:28:70:88:ff:d6:26:6c:6c:60:04:25:4e:55:7e:
+#                     7d:ef:bf:94:48:de:b7:1d:dd:70:8d:05:5f:88:a5:
+#                     9b:f2:c2:ee:ea:d1:40:41:6d:62:38:1d:56:06:c5:
+#                     03:47:51:20:19:fc:7b:10:0b:0e:62:ae:76:55:bf:
+#                     5f:77:be:3e:49:01:53:3d:98:25:03:76:24:5a:1d:
+#                     b4:db:89:ea:79:e5:b6:b3:3b:3f:ba:4c:28:41:7f:
+#                     06:ac:6a:8e:c1:d0:f6:05:1d:7d:e6:42:86:e3:a5:
+#                     d5:47
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 C4:79:CA:8E:A1:4E:03:1D:1C:DC:6B:DB:31:5B:94:3E:3F:30:7F:2D
+#     Signature Algorithm: sha256WithRSAEncryption
+#          2d:c5:13:cf:56:80:7b:7a:78:bd:9f:ae:2c:99:e7:ef:da:df:
+#          94:5e:09:69:a7:e7:6e:68:8c:bd:72:be:47:a9:0e:97:12:b8:
+#          4a:f1:64:d3:39:df:25:34:d4:c1:cd:4e:81:f0:0f:04:c4:24:
+#          b3:34:96:c6:a6:aa:30:df:68:61:73:d7:f9:8e:85:89:ef:0e:
+#          5e:95:28:4a:2a:27:8f:10:8e:2e:7c:86:c4:02:9e:da:0c:77:
+#          65:0e:44:0d:92:fd:fd:b3:16:36:fa:11:0d:1d:8c:0e:07:89:
+#          6a:29:56:f7:72:f4:dd:15:9c:77:35:66:57:ab:13:53:d8:8e:
+#          c1:40:c5:d7:13:16:5a:72:c7:b7:69:01:c4:7a:b1:83:01:68:
+#          7d:8d:41:a1:94:18:c1:25:5c:fc:f0:fe:83:02:87:7c:0d:0d:
+#          cf:2e:08:5c:4a:40:0d:3e:ec:81:61:e6:24:db:ca:e0:0e:2d:
+#          07:b2:3e:56:dc:8d:f5:41:85:07:48:9b:0c:0b:cb:49:3f:7d:
+#          ec:b7:fd:cb:8d:67:89:1a:ab:ed:bb:1e:a3:00:08:08:17:2a:
+#          82:5c:31:5d:46:8a:2d:0f:86:9b:74:d9:45:fb:d4:40:b1:7a:
+#          aa:68:2d:86:b2:99:22:e1:c1:2b:c7:9c:f8:f3:5f:a8:82:12:
+#          eb:19:11:2d
+-----BEGIN CERTIFICATE-----
+MIID/jCCAuagAwIBAgIQFaxulBmyeUtB9iepwxgPHzANBgkqhkiG9w0BAQsFADCB
+mDELMAkGA1UEBhMCVVMxFjAUBgNVBAoTDUdlb1RydXN0IEluYy4xOTA3BgNVBAsT
+MChjKSAyMDA4IEdlb1RydXN0IEluYy4gLSBGb3IgYXV0aG9yaXplZCB1c2Ugb25s
+eTE2MDQGA1UEAxMtR2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhv
+cml0eSAtIEczMB4XDTA4MDQwMjAwMDAwMFoXDTM3MTIwMTIzNTk1OVowgZgxCzAJ
+BgNVBAYTAlVTMRYwFAYDVQQKEw1HZW9UcnVzdCBJbmMuMTkwNwYDVQQLEzAoYykg
+MjAwOCBHZW9UcnVzdCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxNjA0
+BgNVBAMTLUdlb1RydXN0IFByaW1hcnkgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkg
+LSBHMzCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANziXmJYHTNXOTIz
++uvLh4yn1ErdBojqZI4xmKU4kB6Yzy5jK/BGvESyiaHAKAxJcCGVn2TAppMSAmUm
+hsalifD614SgcK9PGpc/BkTVyetyEH3kMSj7HGHmKAdEc5IiaacDiGydY8hS2pgn
+5whMcD60yRLBxWeDXTPzAxHsatBT4tG6NmCUgLthY2xbF37fQJQeqw3CIShwiP/W
+JmxsYAQlTlV+fe+/lEjetx3dcI0FX4ilm/LC7urRQEFtYjgdVgbFA0dRIBn8exAL
+DmKudlW/X3e+PkkBUz2YJQN2JFodtNuJ6nnltrM7P7pMKEF/BqxqjsHQ9gUdfeZC
+huOl1UcCAwEAAaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYw
+HQYDVR0OBBYEFMR5yo6hTgMdHNxr2zFblD4/MH8tMA0GCSqGSIb3DQEBCwUAA4IB
+AQAtxRPPVoB7eni9n64smefv2t+UXglpp+duaIy9cr5HqQ6XErhK8WTTOd8lNNTB
+zU6B8A8ExCSzNJbGpqow32hhc9f5joWJ7w5elShKKiePEI4ufIbEAp7aDHdlDkQN
+kv39sxY2+hENHYwOB4lqKVb3cvTdFZx3NWZXqxNT2I7BQMXXExZacse3aQHEerGD
+AWh9jUGhlBjBJVz88P6DAod8DQ3PLghcSkANPuyBYeYk28rgDi0Hsj5W3I31QYUH
+SJsMC8tJP33st/3LjWeJGqvtux6jAAgIFyqCXDFdRootD4abdNlF+9RAsXqqaC2G
+spki4cErx5z481+oghLrGREt
+-----END CERTIFICATE-----
+# GeoTrust Primary Certification Authority.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             18:ac:b5:6a:fd:69:b6:15:3a:63:6c:af:da:fa:c4:a1
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=GeoTrust Inc., CN=GeoTrust Primary Certification Authority
+#         Validity
+#             Not Before: Nov 27 00:00:00 2006 GMT
+#             Not After : Jul 16 23:59:59 2036 GMT
+#         Subject: C=US, O=GeoTrust Inc., CN=GeoTrust Primary Certification Authority
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:be:b8:15:7b:ff:d4:7c:7d:67:ad:83:64:7b:c8:
+#                     42:53:2d:df:f6:84:08:20:61:d6:01:59:6a:9c:44:
+#                     11:af:ef:76:fd:95:7e:ce:61:30:bb:7a:83:5f:02:
+#                     bd:01:66:ca:ee:15:8d:6f:a1:30:9c:bd:a1:85:9e:
+#                     94:3a:f3:56:88:00:31:cf:d8:ee:6a:96:02:d9:ed:
+#                     03:8c:fb:75:6d:e7:ea:b8:55:16:05:16:9a:f4:e0:
+#                     5e:b1:88:c0:64:85:5c:15:4d:88:c7:b7:ba:e0:75:
+#                     e9:ad:05:3d:9d:c7:89:48:e0:bb:28:c8:03:e1:30:
+#                     93:64:5e:52:c0:59:70:22:35:57:88:8a:f1:95:0a:
+#                     83:d7:bc:31:73:01:34:ed:ef:46:71:e0:6b:02:a8:
+#                     35:72:6b:97:9b:66:e0:cb:1c:79:5f:d8:1a:04:68:
+#                     1e:47:02:e6:9d:60:e2:36:97:01:df:ce:35:92:df:
+#                     be:67:c7:6d:77:59:3b:8f:9d:d6:90:15:94:bc:42:
+#                     34:10:c1:39:f9:b1:27:3e:7e:d6:8a:75:c5:b2:af:
+#                     96:d3:a2:de:9b:e4:98:be:7d:e1:e9:81:ad:b6:6f:
+#                     fc:d7:0e:da:e0:34:b0:0d:1a:77:e7:e3:08:98:ef:
+#                     58:fa:9c:84:b7:36:af:c2:df:ac:d2:f4:10:06:70:
+#                     71:35
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 2C:D5:50:41:97:15:8B:F0:8F:36:61:5B:4A:FB:6B:D9:99:C9:33:92
+#     Signature Algorithm: sha1WithRSAEncryption
+#          5a:70:7f:2c:dd:b7:34:4f:f5:86:51:a9:26:be:4b:b8:aa:f1:
+#          71:0d:dc:61:c7:a0:ea:34:1e:7a:77:0f:04:35:e8:27:8f:6c:
+#          90:bf:91:16:24:46:3e:4a:4e:ce:2b:16:d5:0b:52:1d:fc:1f:
+#          67:a2:02:45:31:4f:ce:f3:fa:03:a7:79:9d:53:6a:d9:da:63:
+#          3a:f8:80:d7:d3:99:e1:a5:e1:be:d4:55:71:98:35:3a:be:93:
+#          ea:ae:ad:42:b2:90:6f:e0:fc:21:4d:35:63:33:89:49:d6:9b:
+#          4e:ca:c7:e7:4e:09:00:f7:da:c7:ef:99:62:99:77:b6:95:22:
+#          5e:8a:a0:ab:f4:b8:78:98:ca:38:19:99:c9:72:9e:78:cd:4b:
+#          ac:af:19:a0:73:12:2d:fc:c2:41:ba:81:91:da:16:5a:31:b7:
+#          f9:b4:71:80:12:48:99:72:73:5a:59:53:c1:63:52:33:ed:a7:
+#          c9:d2:39:02:70:fa:e0:b1:42:66:29:aa:9b:51:ed:30:54:22:
+#          14:5f:d9:ab:1d:c1:e4:94:f0:f8:f5:2b:f7:ea:ca:78:46:d6:
+#          b8:91:fd:a6:0d:2b:1a:14:01:3e:80:f0:42:a0:95:07:5e:6d:
+#          cd:cc:4b:a4:45:8d:ab:12:e8:b3:de:5a:e5:a0:7c:e8:0f:22:
+#          1d:5a:e9:59
+-----BEGIN CERTIFICATE-----
+MIIDfDCCAmSgAwIBAgIQGKy1av1pthU6Y2yv2vrEoTANBgkqhkiG9w0BAQUFADBY
+MQswCQYDVQQGEwJVUzEWMBQGA1UEChMNR2VvVHJ1c3QgSW5jLjExMC8GA1UEAxMo
+R2VvVHJ1c3QgUHJpbWFyeSBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjEx
+MjcwMDAwMDBaFw0zNjA3MTYyMzU5NTlaMFgxCzAJBgNVBAYTAlVTMRYwFAYDVQQK
+Ew1HZW9UcnVzdCBJbmMuMTEwLwYDVQQDEyhHZW9UcnVzdCBQcmltYXJ5IENlcnRp
+ZmljYXRpb24gQXV0aG9yaXR5MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKC
+AQEAvrgVe//UfH1nrYNke8hCUy3f9oQIIGHWAVlqnEQRr+92/ZV+zmEwu3qDXwK9
+AWbK7hWNb6EwnL2hhZ6UOvNWiAAxz9juapYC2e0DjPt1befquFUWBRaa9OBesYjA
+ZIVcFU2Ix7e64HXprQU9nceJSOC7KMgD4TCTZF5SwFlwIjVXiIrxlQqD17wxcwE0
+7e9GceBrAqg1cmuXm2bgyxx5X9gaBGgeRwLmnWDiNpcB3841kt++Z8dtd1k7j53W
+kBWUvEI0EME5+bEnPn7WinXFsq+W06Lem+SYvn3h6YGttm/81w7a4DSwDRp35+MI
+mO9Y+pyEtzavwt+s0vQQBnBxNQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4G
+A1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQULNVQQZcVi/CPNmFbSvtr2ZnJM5IwDQYJ
+KoZIhvcNAQEFBQADggEBAFpwfyzdtzRP9YZRqSa+S7iq8XEN3GHHoOo0Hnp3DwQ1
+6CePbJC/kRYkRj5KTs4rFtULUh38H2eiAkUxT87z+gOneZ1TatnaYzr4gNfTmeGl
+4b7UVXGYNTq+k+qurUKykG/g/CFNNWMziUnWm07Kx+dOCQD32sfvmWKZd7aVIl6K
+oKv0uHiYyjgZmclynnjNS6yvGaBzEi38wkG6gZHaFloxt/m0cYASSJlyc1pZU8Fj
+UjPtp8nSOQJw+uCxQmYpqptR7TBUIhRf2asdweSU8Pj1K/fqynhG1riR/aYNKxoU
+AT6A8EKglQdebc3MS6RFjasS6LPeWuWgfOgPIh1a6Vk=
+-----END CERTIFICATE-----
+# Go Daddy Class 2 Certification Authority.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 0 (0x0)
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=The Go Daddy Group, Inc., OU=Go Daddy Class 2 Certification Authority
+#         Validity
+#             Not Before: Jun 29 17:06:20 2004 GMT
+#             Not After : Jun 29 17:06:20 2034 GMT
+#         Subject: C=US, O=The Go Daddy Group, Inc., OU=Go Daddy Class 2 Certification Authority
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:de:9d:d7:ea:57:18:49:a1:5b:eb:d7:5f:48:86:
+#                     ea:be:dd:ff:e4:ef:67:1c:f4:65:68:b3:57:71:a0:
+#                     5e:77:bb:ed:9b:49:e9:70:80:3d:56:18:63:08:6f:
+#                     da:f2:cc:d0:3f:7f:02:54:22:54:10:d8:b2:81:d4:
+#                     c0:75:3d:4b:7f:c7:77:c3:3e:78:ab:1a:03:b5:20:
+#                     6b:2f:6a:2b:b1:c5:88:7e:c4:bb:1e:b0:c1:d8:45:
+#                     27:6f:aa:37:58:f7:87:26:d7:d8:2d:f6:a9:17:b7:
+#                     1f:72:36:4e:a6:17:3f:65:98:92:db:2a:6e:5d:a2:
+#                     fe:88:e0:0b:de:7f:e5:8d:15:e1:eb:cb:3a:d5:e2:
+#                     12:a2:13:2d:d8:8e:af:5f:12:3d:a0:08:05:08:b6:
+#                     5c:a5:65:38:04:45:99:1e:a3:60:60:74:c5:41:a5:
+#                     72:62:1b:62:c5:1f:6f:5f:1a:42:be:02:51:65:a8:
+#                     ae:23:18:6a:fc:78:03:a9:4d:7f:80:c3:fa:ab:5a:
+#                     fc:a1:40:a4:ca:19:16:fe:b2:c8:ef:5e:73:0d:ee:
+#                     77:bd:9a:f6:79:98:bc:b1:07:67:a2:15:0d:dd:a0:
+#                     58:c6:44:7b:0a:3e:62:28:5f:ba:41:07:53:58:cf:
+#                     11:7e:38:74:c5:f8:ff:b5:69:90:8f:84:74:ea:97:
+#                     1b:af
+#                 Exponent: 3 (0x3)
+#         X509v3 extensions:
+#             X509v3 Subject Key Identifier:
+#                 D2:C4:B0:D2:91:D4:4C:11:71:B3:61:CB:3D:A1:FE:DD:A8:6A:D4:E3
+#             X509v3 Authority Key Identifier:
+#                 keyid:D2:C4:B0:D2:91:D4:4C:11:71:B3:61:CB:3D:A1:FE:DD:A8:6A:D4:E3
+#                 DirName:/C=US/O=The Go Daddy Group, Inc./OU=Go Daddy Class 2 Certification Authority
+#                 serial:00
+#
+#             X509v3 Basic Constraints:
+#                 CA:TRUE
+#     Signature Algorithm: sha1WithRSAEncryption
+#          32:4b:f3:b2:ca:3e:91:fc:12:c6:a1:07:8c:8e:77:a0:33:06:
+#          14:5c:90:1e:18:f7:08:a6:3d:0a:19:f9:87:80:11:6e:69:e4:
+#          96:17:30:ff:34:91:63:72:38:ee:cc:1c:01:a3:1d:94:28:a4:
+#          31:f6:7a:c4:54:d7:f6:e5:31:58:03:a2:cc:ce:62:db:94:45:
+#          73:b5:bf:45:c9:24:b5:d5:82:02:ad:23:79:69:8d:b8:b6:4d:
+#          ce:cf:4c:ca:33:23:e8:1c:88:aa:9d:8b:41:6e:16:c9:20:e5:
+#          89:9e:cd:3b:da:70:f7:7e:99:26:20:14:54:25:ab:6e:73:85:
+#          e6:9b:21:9d:0a:6c:82:0e:a8:f8:c2:0c:fa:10:1e:6c:96:ef:
+#          87:0d:c4:0f:61:8b:ad:ee:83:2b:95:f8:8e:92:84:72:39:eb:
+#          20:ea:83:ed:83:cd:97:6e:08:bc:eb:4e:26:b6:73:2b:e4:d3:
+#          f6:4c:fe:26:71:e2:61:11:74:4a:ff:57:1a:87:0f:75:48:2e:
+#          cf:51:69:17:a0:02:12:61:95:d5:d1:40:b2:10:4c:ee:c4:ac:
+#          10:43:a6:a5:9e:0a:d5:95:62:9a:0d:cf:88:82:c5:32:0c:e4:
+#          2b:9f:45:e6:0d:9f:28:9c:b1:b9:2a:5a:57:ad:37:0f:af:1d:
+#          7f:db:bd:9f
+-----BEGIN CERTIFICATE-----
+MIIEADCCAuigAwIBAgIBADANBgkqhkiG9w0BAQUFADBjMQswCQYDVQQGEwJVUzEh
+MB8GA1UEChMYVGhlIEdvIERhZGR5IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBE
+YWRkeSBDbGFzcyAyIENlcnRpZmljYXRpb24gQXV0aG9yaXR5MB4XDTA0MDYyOTE3
+MDYyMFoXDTM0MDYyOTE3MDYyMFowYzELMAkGA1UEBhMCVVMxITAfBgNVBAoTGFRo
+ZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28gRGFkZHkgQ2xhc3Mg
+MiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTCCASAwDQYJKoZIhvcNAQEBBQADggEN
+ADCCAQgCggEBAN6d1+pXGEmhW+vXX0iG6r7d/+TvZxz0ZWizV3GgXne77ZtJ6XCA
+PVYYYwhv2vLM0D9/AlQiVBDYsoHUwHU9S3/Hd8M+eKsaA7Ugay9qK7HFiH7Eux6w
+wdhFJ2+qN1j3hybX2C32qRe3H3I2TqYXP2WYktsqbl2i/ojgC95/5Y0V4evLOtXi
+EqITLdiOr18SPaAIBQi2XKVlOARFmR6jYGB0xUGlcmIbYsUfb18aQr4CUWWoriMY
+avx4A6lNf4DD+qta/KFApMoZFv6yyO9ecw3ud72a9nmYvLEHZ6IVDd2gWMZEewo+
+YihfukEHU1jPEX44dMX4/7VpkI+EdOqXG68CAQOjgcAwgb0wHQYDVR0OBBYEFNLE
+sNKR1EwRcbNhyz2h/t2oatTjMIGNBgNVHSMEgYUwgYKAFNLEsNKR1EwRcbNhyz2h
+/t2oatTjoWekZTBjMQswCQYDVQQGEwJVUzEhMB8GA1UEChMYVGhlIEdvIERhZGR5
+IEdyb3VwLCBJbmMuMTEwLwYDVQQLEyhHbyBEYWRkeSBDbGFzcyAyIENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5ggEAMAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQAD
+ggEBADJL87LKPpH8EsahB4yOd6AzBhRckB4Y9wimPQoZ+YeAEW5p5JYXMP80kWNy
+OO7MHAGjHZQopDH2esRU1/blMVgDoszOYtuURXO1v0XJJLXVggKtI3lpjbi2Tc7P
+TMozI+gciKqdi0FuFskg5YmezTvacPd+mSYgFFQlq25zheabIZ0KbIIOqPjCDPoQ
+HmyW74cNxA9hi63ugyuV+I6ShHI56yDqg+2DzZduCLzrTia2cyvk0/ZM/iZx4mER
+dEr/VxqHD3VILs9RaRegAhJhldXRQLIQTO7ErBBDpqWeCtWVYpoNz4iCxTIM5Cuf
+ReYNnyicsbkqWletNw+vHX/bvZ8=
+-----END CERTIFICATE-----
+# Go Daddy Root Certificate Authority - G2.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 0 (0x0)
+#     Signature Algorithm: sha256WithRSAEncryption
+#         Issuer: C=US, ST=Arizona, L=Scottsdale, O=GoDaddy.com, Inc., CN=Go Daddy Root Certificate Authority - G2
+#         Validity
+#             Not Before: Sep  1 00:00:00 2009 GMT
+#             Not After : Dec 31 23:59:59 2037 GMT
+#         Subject: C=US, ST=Arizona, L=Scottsdale, O=GoDaddy.com, Inc., CN=Go Daddy Root Certificate Authority - G2
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:bf:71:62:08:f1:fa:59:34:f7:1b:c9:18:a3:f7:
+#                     80:49:58:e9:22:83:13:a6:c5:20:43:01:3b:84:f1:
+#                     e6:85:49:9f:27:ea:f6:84:1b:4e:a0:b4:db:70:98:
+#                     c7:32:01:b1:05:3e:07:4e:ee:f4:fa:4f:2f:59:30:
+#                     22:e7:ab:19:56:6b:e2:80:07:fc:f3:16:75:80:39:
+#                     51:7b:e5:f9:35:b6:74:4e:a9:8d:82:13:e4:b6:3f:
+#                     a9:03:83:fa:a2:be:8a:15:6a:7f:de:0b:c3:b6:19:
+#                     14:05:ca:ea:c3:a8:04:94:3b:46:7c:32:0d:f3:00:
+#                     66:22:c8:8d:69:6d:36:8c:11:18:b7:d3:b2:1c:60:
+#                     b4:38:fa:02:8c:ce:d3:dd:46:07:de:0a:3e:eb:5d:
+#                     7c:c8:7c:fb:b0:2b:53:a4:92:62:69:51:25:05:61:
+#                     1a:44:81:8c:2c:a9:43:96:23:df:ac:3a:81:9a:0e:
+#                     29:c5:1c:a9:e9:5d:1e:b6:9e:9e:30:0a:39:ce:f1:
+#                     88:80:fb:4b:5d:cc:32:ec:85:62:43:25:34:02:56:
+#                     27:01:91:b4:3b:70:2a:3f:6e:b1:e8:9c:88:01:7d:
+#                     9f:d4:f9:db:53:6d:60:9d:bf:2c:e7:58:ab:b8:5f:
+#                     46:fc:ce:c4:1b:03:3c:09:eb:49:31:5c:69:46:b3:
+#                     e0:47
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 3A:9A:85:07:10:67:28:B6:EF:F6:BD:05:41:6E:20:C1:94:DA:0F:DE
+#     Signature Algorithm: sha256WithRSAEncryption
+#          99:db:5d:79:d5:f9:97:59:67:03:61:f1:7e:3b:06:31:75:2d:
+#          a1:20:8e:4f:65:87:b4:f7:a6:9c:bc:d8:e9:2f:d0:db:5a:ee:
+#          cf:74:8c:73:b4:38:42:da:05:7b:f8:02:75:b8:fd:a5:b1:d7:
+#          ae:f6:d7:de:13:cb:53:10:7e:8a:46:d1:97:fa:b7:2e:2b:11:
+#          ab:90:b0:27:80:f9:e8:9f:5a:e9:37:9f:ab:e4:df:6c:b3:85:
+#          17:9d:3d:d9:24:4f:79:91:35:d6:5f:04:eb:80:83:ab:9a:02:
+#          2d:b5:10:f4:d8:90:c7:04:73:40:ed:72:25:a0:a9:9f:ec:9e:
+#          ab:68:12:99:57:c6:8f:12:3a:09:a4:bd:44:fd:06:15:37:c1:
+#          9b:e4:32:a3:ed:38:e8:d8:64:f3:2c:7e:14:fc:02:ea:9f:cd:
+#          ff:07:68:17:db:22:90:38:2d:7a:8d:d1:54:f1:69:e3:5f:33:
+#          ca:7a:3d:7b:0a:e3:ca:7f:5f:39:e5:e2:75:ba:c5:76:18:33:
+#          ce:2c:f0:2f:4c:ad:f7:b1:e7:ce:4f:a8:c4:9b:4a:54:06:c5:
+#          7f:7d:d5:08:0f:e2:1c:fe:7e:17:b8:ac:5e:f6:d4:16:b2:43:
+#          09:0c:4d:f6:a7:6b:b4:99:84:65:ca:7a:88:e2:e2:44:be:5c:
+#          f7:ea:1c:f5
+-----BEGIN CERTIFICATE-----
+MIIDxTCCAq2gAwIBAgIBADANBgkqhkiG9w0BAQsFADCBgzELMAkGA1UEBhMCVVMx
+EDAOBgNVBAgTB0FyaXpvbmExEzARBgNVBAcTClNjb3R0c2RhbGUxGjAYBgNVBAoT
+EUdvRGFkZHkuY29tLCBJbmMuMTEwLwYDVQQDEyhHbyBEYWRkeSBSb290IENlcnRp
+ZmljYXRlIEF1dGhvcml0eSAtIEcyMB4XDTA5MDkwMTAwMDAwMFoXDTM3MTIzMTIz
+NTk1OVowgYMxCzAJBgNVBAYTAlVTMRAwDgYDVQQIEwdBcml6b25hMRMwEQYDVQQH
+EwpTY290dHNkYWxlMRowGAYDVQQKExFHb0RhZGR5LmNvbSwgSW5jLjExMC8GA1UE
+AxMoR28gRGFkZHkgUm9vdCBDZXJ0aWZpY2F0ZSBBdXRob3JpdHkgLSBHMjCCASIw
+DQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAL9xYgjx+lk09xvJGKP3gElY6SKD
+E6bFIEMBO4Tx5oVJnyfq9oQbTqC023CYxzIBsQU+B07u9PpPL1kwIuerGVZr4oAH
+/PMWdYA5UXvl+TW2dE6pjYIT5LY/qQOD+qK+ihVqf94Lw7YZFAXK6sOoBJQ7Rnwy
+DfMAZiLIjWltNowRGLfTshxgtDj6AozO091GB94KPutdfMh8+7ArU6SSYmlRJQVh
+GkSBjCypQ5Yj36w6gZoOKcUcqeldHraenjAKOc7xiID7S13MMuyFYkMlNAJWJwGR
+tDtwKj9useiciAF9n9T521NtYJ2/LOdYq7hfRvzOxBsDPAnrSTFcaUaz4EcCAwEA
+AaNCMEAwDwYDVR0TAQH/BAUwAwEB/zAOBgNVHQ8BAf8EBAMCAQYwHQYDVR0OBBYE
+FDqahQcQZyi27/a9BUFuIMGU2g/eMA0GCSqGSIb3DQEBCwUAA4IBAQCZ21151fmX
+WWcDYfF+OwYxdS2hII5PZYe096acvNjpL9DbWu7PdIxztDhC2gV7+AJ1uP2lsdeu
+9tfeE8tTEH6KRtGX+rcuKxGrkLAngPnon1rpN5+r5N9ss4UXnT3ZJE95kTXWXwTr
+gIOrmgIttRD02JDHBHNA7XIloKmf7J6raBKZV8aPEjoJpL1E/QYVN8Gb5DKj7Tjo
+2GTzLH4U/ALqn83/B2gX2yKQOC16jdFU8WnjXzPKej17CuPKf1855eJ1usV2GDPO
+LPAvTK33sefOT6jEm0pUBsV/fdUID+Ic/n4XuKxe9tQWskMJDE32p2u0mYRlynqI
+4uJEvlz36hz1
+-----END CERTIFICATE-----
+# Go Daddy Secure Certification Authority serialNumber=07969287.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 769 (0x301)
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=The Go Daddy Group, Inc., OU=Go Daddy Class 2 Certification Authority
+#         Validity
+#             Not Before: Nov 16 01:54:37 2006 GMT
+#             Not After : Nov 16 01:54:37 2026 GMT
+#         Subject: C=US, ST=Arizona, L=Scottsdale, O=GoDaddy.com, Inc., OU=http://certificates.godaddy.com/repository, CN=Go Daddy Secure Certification Authority/serialNumber=07969287
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:c4:2d:d5:15:8c:9c:26:4c:ec:32:35:eb:5f:b8:
+#                     59:01:5a:a6:61:81:59:3b:70:63:ab:e3:dc:3d:c7:
+#                     2a:b8:c9:33:d3:79:e4:3a:ed:3c:30:23:84:8e:b3:
+#                     30:14:b6:b2:87:c3:3d:95:54:04:9e:df:99:dd:0b:
+#                     25:1e:21:de:65:29:7e:35:a8:a9:54:eb:f6:f7:32:
+#                     39:d4:26:55:95:ad:ef:fb:fe:58:86:d7:9e:f4:00:
+#                     8d:8c:2a:0c:bd:42:04:ce:a7:3f:04:f6:ee:80:f2:
+#                     aa:ef:52:a1:69:66:da:be:1a:ad:5d:da:2c:66:ea:
+#                     1a:6b:bb:e5:1a:51:4a:00:2f:48:c7:98:75:d8:b9:
+#                     29:c8:ee:f8:66:6d:0a:9c:b3:f3:fc:78:7c:a2:f8:
+#                     a3:f2:b5:c3:f3:b9:7a:91:c1:a7:e6:25:2e:9c:a8:
+#                     ed:12:65:6e:6a:f6:12:44:53:70:30:95:c3:9c:2b:
+#                     58:2b:3d:08:74:4a:f2:be:51:b0:bf:87:d0:4c:27:
+#                     58:6b:b5:35:c5:9d:af:17:31:f8:0b:8f:ee:ad:81:
+#                     36:05:89:08:98:cf:3a:af:25:87:c0:49:ea:a7:fd:
+#                     67:f7:45:8e:97:cc:14:39:e2:36:85:b5:7e:1a:37:
+#                     fd:16:f6:71:11:9a:74:30:16:fe:13:94:a3:3f:84:
+#                     0d:4f
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Subject Key Identifier:
+#                 FD:AC:61:32:93:6C:45:D6:E2:EE:85:5F:9A:BA:E7:76:99:68:CC:E7
+#             X509v3 Authority Key Identifier:
+#                 keyid:D2:C4:B0:D2:91:D4:4C:11:71:B3:61:CB:3D:A1:FE:DD:A8:6A:D4:E3
+#
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE, pathlen:0
+#             Authority Information Access:
+#                 OCSP - URI:http://ocsp.godaddy.com
+#
+#             X509v3 CRL Distribution Points:
+#
+#                 Full Name:
+#                   URI:http://certificates.godaddy.com/repository/gdroot.crl
+#
+#             X509v3 Certificate Policies:
+#                 Policy: X509v3 Any Policy
+#                   CPS: http://certificates.godaddy.com/repository
+#
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#     Signature Algorithm: sha1WithRSAEncryption
+#          d2:86:c0:ec:bd:f9:a1:b6:67:ee:66:0b:a2:06:3a:04:50:8e:
+#          15:72:ac:4a:74:95:53:cb:37:cb:44:49:ef:07:90:6b:33:d9:
+#          96:f0:94:56:a5:13:30:05:3c:85:32:21:7b:c9:c7:0a:a8:24:
+#          a4:90:de:46:d3:25:23:14:03:67:c2:10:d6:6f:0f:5d:7b:7a:
+#          cc:9f:c5:58:2a:c1:c4:9e:21:a8:5a:f3:ac:a4:46:f3:9e:e4:
+#          63:cb:2f:90:a4:29:29:01:d9:72:2c:29:df:37:01:27:bc:4f:
+#          ee:68:d3:21:8f:c0:b3:e4:f5:09:ed:d2:10:aa:53:b4:be:f0:
+#          cc:59:0b:d6:3b:96:1c:95:24:49:df:ce:ec:fd:a7:48:91:14:
+#          45:0e:3a:36:6f:da:45:b3:45:a2:41:c9:d4:d7:44:4e:3e:b9:
+#          74:76:d5:a2:13:55:2c:c6:87:a3:b5:99:ac:06:84:87:7f:75:
+#          06:fc:bf:14:4c:0e:cc:6e:c4:df:3d:b7:12:71:f4:e8:f1:51:
+#          40:22:28:49:e0:1d:4b:87:a8:34:cc:06:a2:dd:12:5a:d1:86:
+#          36:64:03:35:6f:6f:77:6e:eb:f2:85:50:98:5e:ab:03:53:ad:
+#          91:23:63:1f:16:9c:cd:b9:b2:05:63:3a:e1:f4:68:1b:17:05:
+#          35:95:53:ee
+-----BEGIN CERTIFICATE-----
+MIIE3jCCA8agAwIBAgICAwEwDQYJKoZIhvcNAQEFBQAwYzELMAkGA1UEBhMCVVMx
+ITAfBgNVBAoTGFRoZSBHbyBEYWRkeSBHcm91cCwgSW5jLjExMC8GA1UECxMoR28g
+RGFkZHkgQ2xhc3MgMiBDZXJ0aWZpY2F0aW9uIEF1dGhvcml0eTAeFw0wNjExMTYw
+MTU0MzdaFw0yNjExMTYwMTU0MzdaMIHKMQswCQYDVQQGEwJVUzEQMA4GA1UECBMH
+QXJpem9uYTETMBEGA1UEBxMKU2NvdHRzZGFsZTEaMBgGA1UEChMRR29EYWRkeS5j
+b20sIEluYy4xMzAxBgNVBAsTKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5j
+b20vcmVwb3NpdG9yeTEwMC4GA1UEAxMnR28gRGFkZHkgU2VjdXJlIENlcnRpZmlj
+YXRpb24gQXV0aG9yaXR5MREwDwYDVQQFEwgwNzk2OTI4NzCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAMQt1RWMnCZM7DI161+4WQFapmGBWTtwY6vj3D3H
+KrjJM9N55DrtPDAjhI6zMBS2sofDPZVUBJ7fmd0LJR4h3mUpfjWoqVTr9vcyOdQm
+VZWt7/v+WIbXnvQAjYwqDL1CBM6nPwT27oDyqu9SoWlm2r4arV3aLGbqGmu75RpR
+SgAvSMeYddi5Kcju+GZtCpyz8/x4fKL4o/K1w/O5epHBp+YlLpyo7RJlbmr2EkRT
+cDCVw5wrWCs9CHRK8r5RsL+H0EwnWGu1NcWdrxcx+AuP7q2BNgWJCJjPOq8lh8BJ
+6qf9Z/dFjpfMFDniNoW1fho3/Rb2cRGadDAW/hOUoz+EDU8CAwEAAaOCATIwggEu
+MB0GA1UdDgQWBBT9rGEyk2xF1uLuhV+auud2mWjM5zAfBgNVHSMEGDAWgBTSxLDS
+kdRMEXGzYcs9of7dqGrU4zASBgNVHRMBAf8ECDAGAQH/AgEAMDMGCCsGAQUFBwEB
+BCcwJTAjBggrBgEFBQcwAYYXaHR0cDovL29jc3AuZ29kYWRkeS5jb20wRgYDVR0f
+BD8wPTA7oDmgN4Y1aHR0cDovL2NlcnRpZmljYXRlcy5nb2RhZGR5LmNvbS9yZXBv
+c2l0b3J5L2dkcm9vdC5jcmwwSwYDVR0gBEQwQjBABgRVHSAAMDgwNgYIKwYBBQUH
+AgEWKmh0dHA6Ly9jZXJ0aWZpY2F0ZXMuZ29kYWRkeS5jb20vcmVwb3NpdG9yeTAO
+BgNVHQ8BAf8EBAMCAQYwDQYJKoZIhvcNAQEFBQADggEBANKGwOy9+aG2Z+5mC6IG
+OgRQjhVyrEp0lVPLN8tESe8HkGsz2ZbwlFalEzAFPIUyIXvJxwqoJKSQ3kbTJSMU
+A2fCENZvD117esyfxVgqwcSeIaha86ykRvOe5GPLL5CkKSkB2XIsKd83ASe8T+5o
+0yGPwLPk9Qnt0hCqU7S+8MxZC9Y7lhyVJEnfzuz9p0iRFEUOOjZv2kWzRaJBydTX
+RE4+uXR21aITVSzGh6O1mawGhId/dQb8vxRMDsxuxN89txJx9OjxUUAiKEngHUuH
+qDTMBqLdElrRhjZkAzVvb3du6/KFUJheqwNTrZEjYx8WnM25sgVjOuH0aBsXBTWV
+U+4=
+-----END CERTIFICATE-----
+# Thawte Premium Server CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number: 1 (0x1)
+#     Signature Algorithm: md5WithRSAEncryption
+#         Issuer: C=ZA, ST=Western Cape, L=Cape Town, O=Thawte Consulting cc, OU=Certification Services Division, CN=Thawte Premium Server CA/emailAddress=premium-server@thawte.com
+#         Validity
+#             Not Before: Aug  1 00:00:00 1996 GMT
+#             Not After : Dec 31 23:59:59 2020 GMT
+#         Subject: C=ZA, ST=Western Cape, L=Cape Town, O=Thawte Consulting cc, OU=Certification Services Division, CN=Thawte Premium Server CA/emailAddress=premium-server@thawte.com
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (1024 bit)
+#                 Modulus:
+#                     00:d2:36:36:6a:8b:d7:c2:5b:9e:da:81:41:62:8f:
+#                     38:ee:49:04:55:d6:d0:ef:1c:1b:95:16:47:ef:18:
+#                     48:35:3a:52:f4:2b:6a:06:8f:3b:2f:ea:56:e3:af:
+#                     86:8d:9e:17:f7:9e:b4:65:75:02:4d:ef:cb:09:a2:
+#                     21:51:d8:9b:d0:67:d0:ba:0d:92:06:14:73:d4:93:
+#                     cb:97:2a:00:9c:5c:4e:0c:bc:fa:15:52:fc:f2:44:
+#                     6e:da:11:4a:6e:08:9f:2f:2d:e3:f9:aa:3a:86:73:
+#                     b6:46:53:58:c8:89:05:bd:83:11:b8:73:3f:aa:07:
+#                     8d:f4:42:4d:e7:40:9d:1c:37
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#     Signature Algorithm: md5WithRSAEncryption
+#          26:48:2c:16:c2:58:fa:e8:16:74:0c:aa:aa:5f:54:3f:f2:d7:
+#          c9:78:60:5e:5e:6e:37:63:22:77:36:7e:b2:17:c4:34:b9:f5:
+#          08:85:fc:c9:01:38:ff:4d:be:f2:16:42:43:e7:bb:5a:46:fb:
+#          c1:c6:11:1f:f1:4a:b0:28:46:c9:c3:c4:42:7d:bc:fa:ab:59:
+#          6e:d5:b7:51:88:11:e3:a4:85:19:6b:82:4c:a4:0c:12:ad:e9:
+#          a4:ae:3f:f1:c3:49:65:9a:8c:c5:c8:3e:25:b7:94:99:bb:92:
+#          32:71:07:f0:86:5e:ed:50:27:a6:0d:a6:23:f9:bb:cb:a6:07:
+#          14:42
+-----BEGIN CERTIFICATE-----
+MIIDJzCCApCgAwIBAgIBATANBgkqhkiG9w0BAQQFADCBzjELMAkGA1UEBhMCWkEx
+FTATBgNVBAgTDFdlc3Rlcm4gQ2FwZTESMBAGA1UEBxMJQ2FwZSBUb3duMR0wGwYD
+VQQKExRUaGF3dGUgQ29uc3VsdGluZyBjYzEoMCYGA1UECxMfQ2VydGlmaWNhdGlv
+biBTZXJ2aWNlcyBEaXZpc2lvbjEhMB8GA1UEAxMYVGhhd3RlIFByZW1pdW0gU2Vy
+dmVyIENBMSgwJgYJKoZIhvcNAQkBFhlwcmVtaXVtLXNlcnZlckB0aGF3dGUuY29t
+MB4XDTk2MDgwMTAwMDAwMFoXDTIwMTIzMTIzNTk1OVowgc4xCzAJBgNVBAYTAlpB
+MRUwEwYDVQQIEwxXZXN0ZXJuIENhcGUxEjAQBgNVBAcTCUNhcGUgVG93bjEdMBsG
+A1UEChMUVGhhd3RlIENvbnN1bHRpbmcgY2MxKDAmBgNVBAsTH0NlcnRpZmljYXRp
+b24gU2VydmljZXMgRGl2aXNpb24xITAfBgNVBAMTGFRoYXd0ZSBQcmVtaXVtIFNl
+cnZlciBDQTEoMCYGCSqGSIb3DQEJARYZcHJlbWl1bS1zZXJ2ZXJAdGhhd3RlLmNv
+bTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEA0jY2aovXwlue2oFBYo847kkE
+VdbQ7xwblRZH7xhINTpS9CtqBo87L+pW46+GjZ4X9560ZXUCTe/LCaIhUdib0GfQ
+ug2SBhRz1JPLlyoAnFxODLz6FVL88kRu2hFKbgifLy3j+ao6hnO2RlNYyIkFvYMR
+uHM/qgeN9EJN50CdHDcCAwEAAaMTMBEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG
+9w0BAQQFAAOBgQAmSCwWwlj66BZ0DKqqX1Q/8tfJeGBeXm43YyJ3Nn6yF8Q0ufUI
+hfzJATj/Tb7yFkJD57taRvvBxhEf8UqwKEbJw8RCfbz6q1lu1bdRiBHjpIUZa4JM
+pAwSremkrj/xw0llmozFyD4lt5SZu5IycQfwhl7tUCemDaYj+bvLpgcUQg==
+-----END CERTIFICATE-----
+# Thawte Primary Root CA - G2.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             35:fc:26:5c:d9:84:4f:c9:3d:26:3d:57:9b:ae:d7:56
+#     Signature Algorithm: ecdsa-with-SHA384
+#         Issuer: C=US, O=thawte, Inc., OU=(c) 2007 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA - G2
+#         Validity
+#             Not Before: Nov  5 00:00:00 2007 GMT
+#             Not After : Jan 18 23:59:59 2038 GMT
+#         Subject: C=US, O=thawte, Inc., OU=(c) 2007 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA - G2
+#         Subject Public Key Info:
+#             Public Key Algorithm: id-ecPublicKey
+#                 Public-Key: (384 bit)
+#                 pub:
+#                     04:a2:d5:9c:82:7b:95:9d:f1:52:78:87:fe:8a:16:
+#                     bf:05:e6:df:a3:02:4f:0d:07:c6:00:51:ba:0c:02:
+#                     52:2d:22:a4:42:39:c4:fe:8f:ea:c9:c1:be:d4:4d:
+#                     ff:9f:7a:9e:e2:b1:7c:9a:ad:a7:86:09:73:87:d1:
+#                     e7:9a:e3:7a:a5:aa:6e:fb:ba:b3:70:c0:67:88:a2:
+#                     35:d4:a3:9a:b1:fd:ad:c2:ef:31:fa:a8:b9:f3:fb:
+#                     08:c6:91:d1:fb:29:95
+#                 ASN1 OID: secp384r1
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 9A:D8:00:30:00:E7:6B:7F:85:18:EE:8B:B6:CE:8A:0C:F8:11:E1:BB
+#     Signature Algorithm: ecdsa-with-SHA384
+#          30:66:02:31:00:dd:f8:e0:57:47:5b:a7:e6:0a:c3:bd:f5:80:
+#          8a:97:35:0d:1b:89:3c:54:86:77:28:ca:a1:f4:79:de:b5:e6:
+#          38:b0:f0:65:70:8c:7f:02:54:c2:bf:ff:d8:a1:3e:d9:cf:02:
+#          31:00:c4:8d:94:fc:dc:53:d2:dc:9d:78:16:1f:15:33:23:53:
+#          52:e3:5a:31:5d:9d:ca:ae:bd:13:29:44:0d:27:5b:a8:e7:68:
+#          9c:12:f7:58:3f:2e:72:02:57:a3:8f:a1:14:2e
+-----BEGIN CERTIFICATE-----
+MIICiDCCAg2gAwIBAgIQNfwmXNmET8k9Jj1Xm67XVjAKBggqhkjOPQQDAzCBhDEL
+MAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjE4MDYGA1UECxMvKGMp
+IDIwMDcgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxJDAi
+BgNVBAMTG3RoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EgLSBHMjAeFw0wNzExMDUwMDAw
+MDBaFw0zODAxMTgyMzU5NTlaMIGEMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhh
+d3RlLCBJbmMuMTgwNgYDVQQLEy8oYykgMjAwNyB0aGF3dGUsIEluYy4gLSBGb3Ig
+YXV0aG9yaXplZCB1c2Ugb25seTEkMCIGA1UEAxMbdGhhd3RlIFByaW1hcnkgUm9v
+dCBDQSAtIEcyMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEotWcgnuVnfFSeIf+iha/
+BebfowJPDQfGAFG6DAJSLSKkQjnE/o/qycG+1E3/n3qe4rF8mq2nhglzh9HnmuN6
+papu+7qzcMBniKI11KOasf2twu8x+qi58/sIxpHR+ymVo0IwQDAPBgNVHRMBAf8E
+BTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNVHQ4EFgQUmtgAMADna3+FGO6Lts6K
+DPgR4bswCgYIKoZIzj0EAwMDaQAwZgIxAN344FdHW6fmCsO99YCKlzUNG4k8VIZ3
+KMqh9HneteY4sPBlcIx/AlTCv//YoT7ZzwIxAMSNlPzcU9LcnXgWHxUzI1NS41ox
+XZ3Krr0TKUQNJ1uo52icEvdYPy5yAlejj6EULg==
+-----END CERTIFICATE-----
+# Thawte Primary Root CA - G3.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             60:01:97:b7:46:a7:ea:b4:b4:9a:d6:4b:2f:f7:90:fb
+#     Signature Algorithm: sha256WithRSAEncryption
+#         Issuer: C=US, O=thawte, Inc., OU=Certification Services Division, OU=(c) 2008 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA - G3
+#         Validity
+#             Not Before: Apr  2 00:00:00 2008 GMT
+#             Not After : Dec  1 23:59:59 2037 GMT
+#         Subject: C=US, O=thawte, Inc., OU=Certification Services Division, OU=(c) 2008 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA - G3
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:b2:bf:27:2c:fb:db:d8:5b:dd:78:7b:1b:9e:77:
+#                     66:81:cb:3e:bc:7c:ae:f3:a6:27:9a:34:a3:68:31:
+#                     71:38:33:62:e4:f3:71:66:79:b1:a9:65:a3:a5:8b:
+#                     d5:8f:60:2d:3f:42:cc:aa:6b:32:c0:23:cb:2c:41:
+#                     dd:e4:df:fc:61:9c:e2:73:b2:22:95:11:43:18:5f:
+#                     c4:b6:1f:57:6c:0a:05:58:22:c8:36:4c:3a:7c:a5:
+#                     d1:cf:86:af:88:a7:44:02:13:74:71:73:0a:42:59:
+#                     02:f8:1b:14:6b:42:df:6f:5f:ba:6b:82:a2:9d:5b:
+#                     e7:4a:bd:1e:01:72:db:4b:74:e8:3b:7f:7f:7d:1f:
+#                     04:b4:26:9b:e0:b4:5a:ac:47:3d:55:b8:d7:b0:26:
+#                     52:28:01:31:40:66:d8:d9:24:bd:f6:2a:d8:ec:21:
+#                     49:5c:9b:f6:7a:e9:7f:55:35:7e:96:6b:8d:93:93:
+#                     27:cb:92:bb:ea:ac:40:c0:9f:c2:f8:80:cf:5d:f4:
+#                     5a:dc:ce:74:86:a6:3e:6c:0b:53:ca:bd:92:ce:19:
+#                     06:72:e6:0c:5c:38:69:c7:04:d6:bc:6c:ce:5b:f6:
+#                     f7:68:9c:dc:25:15:48:88:a1:e9:a9:f8:98:9c:e0:
+#                     f3:d5:31:28:61:11:6c:67:96:8d:39:99:cb:c2:45:
+#                     24:39
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 AD:6C:AA:94:60:9C:ED:E4:FF:FA:3E:0A:74:2B:63:03:F7:B6:59:BF
+#     Signature Algorithm: sha256WithRSAEncryption
+#          1a:40:d8:95:65:ac:09:92:89:c6:39:f4:10:e5:a9:0e:66:53:
+#          5d:78:de:fa:24:91:bb:e7:44:51:df:c6:16:34:0a:ef:6a:44:
+#          51:ea:2b:07:8a:03:7a:c3:eb:3f:0a:2c:52:16:a0:2b:43:b9:
+#          25:90:3f:70:a9:33:25:6d:45:1a:28:3b:27:cf:aa:c3:29:42:
+#          1b:df:3b:4c:c0:33:34:5b:41:88:bf:6b:2b:65:af:28:ef:b2:
+#          f5:c3:aa:66:ce:7b:56:ee:b7:c8:cb:67:c1:c9:9c:1a:18:b8:
+#          c4:c3:49:03:f1:60:0e:50:cd:46:c5:f3:77:79:f7:b6:15:e0:
+#          38:db:c7:2f:28:a0:0c:3f:77:26:74:d9:25:12:da:31:da:1a:
+#          1e:dc:29:41:91:22:3c:69:a7:bb:02:f2:b6:5c:27:03:89:f4:
+#          06:ea:9b:e4:72:82:e3:a1:09:c1:e9:00:19:d3:3e:d4:70:6b:
+#          ba:71:a6:aa:58:ae:f4:bb:e9:6c:b6:ef:87:cc:9b:bb:ff:39:
+#          e6:56:61:d3:0a:a7:c4:5c:4c:60:7b:05:77:26:7a:bf:d8:07:
+#          52:2c:62:f7:70:63:d9:39:bc:6f:1c:c2:79:dc:76:29:af:ce:
+#          c5:2c:64:04:5e:88:36:6e:31:d4:40:1a:62:34:36:3f:35:01:
+#          ae:ac:63:a0
+-----BEGIN CERTIFICATE-----
+MIIEKjCCAxKgAwIBAgIQYAGXt0an6rS0mtZLL/eQ+zANBgkqhkiG9w0BAQsFADCB
+rjELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDggdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxJDAiBgNV
+BAMTG3RoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EgLSBHMzAeFw0wODA0MDIwMDAwMDBa
+Fw0zNzEyMDEyMzU5NTlaMIGuMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMdGhhd3Rl
+LCBJbmMuMSgwJgYDVQQLEx9DZXJ0aWZpY2F0aW9uIFNlcnZpY2VzIERpdmlzaW9u
+MTgwNgYDVQQLEy8oYykgMjAwOCB0aGF3dGUsIEluYy4gLSBGb3IgYXV0aG9yaXpl
+ZCB1c2Ugb25seTEkMCIGA1UEAxMbdGhhd3RlIFByaW1hcnkgUm9vdCBDQSAtIEcz
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsr8nLPvb2FvdeHsbnndm
+gcs+vHyu86YnmjSjaDFxODNi5PNxZnmxqWWjpYvVj2AtP0LMqmsywCPLLEHd5N/8
+YZzic7IilRFDGF/Eth9XbAoFWCLINkw6fKXRz4aviKdEAhN0cXMKQlkC+BsUa0Lf
+b1+6a4KinVvnSr0eAXLbS3ToO39/fR8EtCab4LRarEc9VbjXsCZSKAExQGbY2SS9
+9irY7CFJXJv2eul/VTV+lmuNk5Mny5K76qxAwJ/C+IDPXfRa3M50hqY+bAtTyr2S
+zhkGcuYMXDhpxwTWvGzOW/b3aJzcJRVIiKHpqfiYnODz1TEoYRFsZ5aNOZnLwkUk
+OQIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MA4GA1UdDwEB/wQEAwIBBjAdBgNV
+HQ4EFgQUrWyqlGCc7eT/+j4KdCtjA/e2Wb8wDQYJKoZIhvcNAQELBQADggEBABpA
+2JVlrAmSicY59BDlqQ5mU1143vokkbvnRFHfxhY0Cu9qRFHqKweKA3rD6z8KLFIW
+oCtDuSWQP3CpMyVtRRooOyfPqsMpQhvfO0zAMzRbQYi/aytlryjvsvXDqmbOe1bu
+t8jLZ8HJnBoYuMTDSQPxYA5QzUbF83d597YV4Djbxy8ooAw/dyZ02SUS2jHaGh7c
+KUGRIjxpp7sC8rZcJwOJ9Abqm+RyguOhCcHpABnTPtRwa7pxpqpYrvS76Wy274fM
+m7v/OeZWYdMKp8RcTGB7BXcmer/YB1IsYvdwY9k5vG8cwnncdimvzsUsZAReiDZu
+MdRAGmI0Nj81Aa6sY6A=
+-----END CERTIFICATE-----
+# Thawte Primary Root CA.pem
+# Certificate:
+#     Data:
+#         Version: 3 (0x2)
+#         Serial Number:
+#             34:4e:d5:57:20:d5:ed:ec:49:f4:2f:ce:37:db:2b:6d
+#     Signature Algorithm: sha1WithRSAEncryption
+#         Issuer: C=US, O=thawte, Inc., OU=Certification Services Division, OU=(c) 2006 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA
+#         Validity
+#             Not Before: Nov 17 00:00:00 2006 GMT
+#             Not After : Jul 16 23:59:59 2036 GMT
+#         Subject: C=US, O=thawte, Inc., OU=Certification Services Division, OU=(c) 2006 thawte, Inc. - For authorized use only, CN=thawte Primary Root CA
+#         Subject Public Key Info:
+#             Public Key Algorithm: rsaEncryption
+#                 Public-Key: (2048 bit)
+#                 Modulus:
+#                     00:ac:a0:f0:fb:80:59:d4:9c:c7:a4:cf:9d:a1:59:
+#                     73:09:10:45:0c:0d:2c:6e:68:f1:6c:5b:48:68:49:
+#                     59:37:fc:0b:33:19:c2:77:7f:cc:10:2d:95:34:1c:
+#                     e6:eb:4d:09:a7:1c:d2:b8:c9:97:36:02:b7:89:d4:
+#                     24:5f:06:c0:cc:44:94:94:8d:02:62:6f:eb:5a:dd:
+#                     11:8d:28:9a:5c:84:90:10:7a:0d:bd:74:66:2f:6a:
+#                     38:a0:e2:d5:54:44:eb:1d:07:9f:07:ba:6f:ee:e9:
+#                     fd:4e:0b:29:f5:3e:84:a0:01:f1:9c:ab:f8:1c:7e:
+#                     89:a4:e8:a1:d8:71:65:0d:a3:51:7b:ee:bc:d2:22:
+#                     60:0d:b9:5b:9d:df:ba:fc:51:5b:0b:af:98:b2:e9:
+#                     2e:e9:04:e8:62:87:de:2b:c8:d7:4e:c1:4c:64:1e:
+#                     dd:cf:87:58:ba:4a:4f:ca:68:07:1d:1c:9d:4a:c6:
+#                     d5:2f:91:cc:7c:71:72:1c:c5:c0:67:eb:32:fd:c9:
+#                     92:5c:94:da:85:c0:9b:bf:53:7d:2b:09:f4:8c:9d:
+#                     91:1f:97:6a:52:cb:de:09:36:a4:77:d8:7b:87:50:
+#                     44:d5:3e:6e:29:69:fb:39:49:26:1e:09:a5:80:7b:
+#                     40:2d:eb:e8:27:85:c9:fe:61:fd:7e:e6:7c:97:1d:
+#                     d5:9d
+#                 Exponent: 65537 (0x10001)
+#         X509v3 extensions:
+#             X509v3 Basic Constraints: critical
+#                 CA:TRUE
+#             X509v3 Key Usage: critical
+#                 Certificate Sign, CRL Sign
+#             X509v3 Subject Key Identifier:
+#                 7B:5B:45:CF:AF:CE:CB:7A:FD:31:92:1A:6A:B6:F3:46:EB:57:48:50
+#     Signature Algorithm: sha1WithRSAEncryption
+#          79:11:c0:4b:b3:91:b6:fc:f0:e9:67:d4:0d:6e:45:be:55:e8:
+#          93:d2:ce:03:3f:ed:da:25:b0:1d:57:cb:1e:3a:76:a0:4c:ec:
+#          50:76:e8:64:72:0c:a4:a9:f1:b8:8b:d6:d6:87:84:bb:32:e5:
+#          41:11:c0:77:d9:b3:60:9d:eb:1b:d5:d1:6e:44:44:a9:a6:01:
+#          ec:55:62:1d:77:b8:5c:8e:48:49:7c:9c:3b:57:11:ac:ad:73:
+#          37:8e:2f:78:5c:90:68:47:d9:60:60:e6:fc:07:3d:22:20:17:
+#          c4:f7:16:e9:c4:d8:72:f9:c8:73:7c:df:16:2f:15:a9:3e:fd:
+#          6a:27:b6:a1:eb:5a:ba:98:1f:d5:e3:4d:64:0a:9d:13:c8:61:
+#          ba:f5:39:1c:87:ba:b8:bd:7b:22:7f:f6:fe:ac:40:79:e5:ac:
+#          10:6f:3d:8f:1b:79:76:8b:c4:37:b3:21:18:84:e5:36:00:eb:
+#          63:20:99:b9:e9:fe:33:04:bb:41:c8:c1:02:f9:44:63:20:9e:
+#          81:ce:42:d3:d6:3f:2c:76:d3:63:9c:59:dd:8f:a6:e1:0e:a0:
+#          2e:41:f7:2e:95:47:cf:bc:fd:33:f3:f6:0b:61:7e:7e:91:2b:
+#          81:47:c2:27:30:ee:a7:10:5d:37:8f:5c:39:2b:e4:04:f0:7b:
+#          8d:56:8c:68
+-----BEGIN CERTIFICATE-----
+MIIEIDCCAwigAwIBAgIQNE7VVyDV7exJ9C/ON9srbTANBgkqhkiG9w0BAQUFADCB
+qTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5jLjEoMCYGA1UECxMf
+Q2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYGA1UECxMvKGMpIDIw
+MDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxHzAdBgNV
+BAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwHhcNMDYxMTE3MDAwMDAwWhcNMzYw
+NzE2MjM1OTU5WjCBqTELMAkGA1UEBhMCVVMxFTATBgNVBAoTDHRoYXd0ZSwgSW5j
+LjEoMCYGA1UECxMfQ2VydGlmaWNhdGlvbiBTZXJ2aWNlcyBEaXZpc2lvbjE4MDYG
+A1UECxMvKGMpIDIwMDYgdGhhd3RlLCBJbmMuIC0gRm9yIGF1dGhvcml6ZWQgdXNl
+IG9ubHkxHzAdBgNVBAMTFnRoYXd0ZSBQcmltYXJ5IFJvb3QgQ0EwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQCsoPD7gFnUnMekz52hWXMJEEUMDSxuaPFs
+W0hoSVk3/AszGcJ3f8wQLZU0HObrTQmnHNK4yZc2AreJ1CRfBsDMRJSUjQJib+ta
+3RGNKJpchJAQeg29dGYvajig4tVUROsdB58Hum/u6f1OCyn1PoSgAfGcq/gcfomk
+6KHYcWUNo1F77rzSImANuVud37r8UVsLr5iy6S7pBOhih94ryNdOwUxkHt3Ph1i6
+Sk/KaAcdHJ1KxtUvkcx8cXIcxcBn6zL9yZJclNqFwJu/U30rCfSMnZEfl2pSy94J
+NqR32HuHUETVPm4pafs5SSYeCaWAe0At6+gnhcn+Yf1+5nyXHdWdAgMBAAGjQjBA
+MA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgEGMB0GA1UdDgQWBBR7W0XP
+r87Lev0xkhpqtvNG61dIUDANBgkqhkiG9w0BAQUFAAOCAQEAeRHAS7ORtvzw6WfU
+DW5FvlXok9LOAz/t2iWwHVfLHjp2oEzsUHboZHIMpKnxuIvW1oeEuzLlQRHAd9mz
+YJ3rG9XRbkREqaYB7FViHXe4XI5ISXycO1cRrK1zN44veFyQaEfZYGDm/Ac9IiAX
+xPcW6cTYcvnIc3zfFi8VqT79aie2oetaupgf1eNNZAqdE8hhuvU5HIe6uL17In/2
+/qxAeeWsEG89jxt5dovEN7MhGITlNgDrYyCZuen+MwS7QcjBAvlEYyCegc5C09Y/
+LHbTY5xZ3Y+m4Q6gLkH3LpVHz7z9M/P2C2F+fpErgUfCJzDupxBdN49cOSvkBPB7
+jVaMaA==
+-----END CERTIFICATE-----


### PR DESCRIPTION
SSLv3 has known security vulnerabilities.  Dropbox is going to disable
SSLv3 soon, so switch to TLS.
